### PR TITLE
apiとlはserverに、それ以外はフロントで処理したい

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,9 +3,15 @@ runtime: go114
 main: ./server
 
 handlers:
-  - url: /
-    static_files: frontend/dist/index.html
-    upload: frontend/dist/index.html
+  - url: /api/.*
+    script: auto
+    secure: always
+  - url: /l/.*
+    script: auto
+    secure: always
   - url: /(.*\.(html|js))$
     static_files: frontend/dist/\1
     upload: frontend/dist/.*\.(html|js)$
+  - url: /.*
+    static_files: frontend/dist/index.html
+    upload: frontend/dist/index.html

--- a/app.yaml
+++ b/app.yaml
@@ -9,7 +9,7 @@ handlers:
   - url: /l/.*
     script: auto
     secure: always
-  - url: /(.*\.(html|js))$
+  - url: /.*/([^/]*\.(html|js))$
     static_files: frontend/dist/\1
     upload: frontend/dist/.*\.(html|js)$
   - url: /.*

--- a/app.yaml
+++ b/app.yaml
@@ -15,3 +15,4 @@ handlers:
   - url: /.*
     static_files: frontend/dist/index.html
     upload: frontend/dist/index.html
+    secure: always

--- a/app.yaml
+++ b/app.yaml
@@ -12,6 +12,7 @@ handlers:
   - url: /(.*/)*([^/]*\.(html|js))$
     static_files: frontend/dist/\2
     upload: frontend/dist/.*\.(html|js)$
+    secure: always
   - url: /.*
     static_files: frontend/dist/index.html
     upload: frontend/dist/index.html

--- a/app.yaml
+++ b/app.yaml
@@ -9,8 +9,8 @@ handlers:
   - url: /l/.*
     script: auto
     secure: always
-  - url: /.*/([^/]*\.(html|js))$
-    static_files: frontend/dist/\1
+  - url: /(.*/)*([^/]*\.(html|js))$
+    static_files: frontend/dist/\2
     upload: frontend/dist/.*\.(html|js)$
   - url: /.*
     static_files: frontend/dist/index.html

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -150,7 +150,7 @@ requestShortURL rawText =
                 (D.field "hash" (D.nullable D.string))
     in
     Http.post
-        { url = "./api/create"
+        { url = "/api/create"
         , body = Http.jsonBody <| toJson rawText
         , expect = Http.expectJson ReceiveShortURL fromJson
         }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: './index.[contenthash].js'
+    filename: 'index.[contenthash].js'
   },
   plugins: [
     new HtmlWebpackPlugin({ template: './src/index.html' }),


### PR DESCRIPTION
`/api/` と `/l/` 以外なら、全部フロントに飛ばすようにした。
( `/aaa/bbb//ccccc` など。)

これでSPAのURLを扱うことができるようになります。