### PR TITLE
フォーマットのCIでのcheckout時にマージコミットしないようにする

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/server/main.go
+++ b/server/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha512"
 	"encoding/hex"
-	"github.com/labstack/echo/middleware"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"cloud.google.com/go/datastore"
 	"github.com/dev-hato/hato-atama/server/settings"
 	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
 )
 
 var (

--- a/server/main.go
+++ b/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha512"
 	"encoding/hex"
+	"github.com/labstack/echo/middleware"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"cloud.google.com/go/datastore"
 	"github.com/dev-hato/hato-atama/server/settings"
 	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
 )
 
 var (


### PR DESCRIPTION
フォーマットのCIでcheckoutする際にマージコミットしてしまうと意図しない差分になってしまうことがあるので、PRのHEADをcheckoutするようにします。
参考: https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit