### PR TITLE
dependabotによる日次アップデート有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+  - package-ecosystem: "docker"
+    directory: "/gcp/datastore"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+  - package-ecosystem: "docker"
+    directory: "/server"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+  - package-ecosystem: "elm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+  - package-ecosystem: "npm"
+    directory: "/test/e2e"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
dependabotによるパッケージの日次アップデートを有効化します。
一度に大量のPRが来るとCIが大変なことになるので、各設定1つずつPRが投げられるようになっています。

参考: https://docs.github.com/ja/github/administering-a-repository/configuration-options-for-dependency-updates