### PR TITLE
e2e-test-all-docker-composeからe2e-test-mini-docker-composeの依存を消す

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,6 @@ jobs:
 
   e2e-test-all-docker-compose:
     runs-on: ubuntu-latest
-    needs: e2e-test-mini-docker-compose
     env:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1


### PR DESCRIPTION
もう別にいいかなって