### PR TITLE
Update super-linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,16 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.2

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Super-Linter
-        uses: github/super-linter@v3.15.5
+        uses: github/super-linter@v3.16.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: test/e2e/cypress/integration/.*

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,3 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: test/e2e/cypress/integration/.*
+          VALIDATE_GO: false


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/138 より派生。
super-linterをアップデートするとともに、golangci-lintをsuper-linter経由ではなく、直接実行するよう変更します。