### PR TITLE
golangci-lintのCI名修正

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,8 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  golangci:
-    name: lint
+  golangci-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
golangci-lintのCI名が `lint` になっていてBranch protection rule等でわかりづらいため、 `golangci-lint` に変更します。