### PR TITLE
format-goはmasterへのpush時には実行しない

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,8 +1,6 @@
 name: format
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
`format-go` はPRのmasterへのマージ時には実行しなくても良いので、こういったケースでは実行されないようにします。