### PR TITLE
Revert "Bump cypress from 7.2.0 to 7.3.0 in /test/e2e"

### DIFF
--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -737,9 +737,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.3.0.tgz",
-      "integrity": "sha512-aseRCH1tRVCrM6oEfja6fR/bo5l6e4SkHRRSATh27UeN4f/ANC8U7tGIulmrISJVy9xuOkOdbYKbUb2MNM+nrw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.2.0.tgz",
+      "integrity": "sha512-lHHGay+YsffDn4M0bkkwezylBVHUpwwhtqte4LNPrFRCHy77X38+1PUe3neFb3glVTM+rbILtTN6FhO2djcOuQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3760,9 +3760,9 @@
       }
     },
     "cypress": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.3.0.tgz",
-      "integrity": "sha512-aseRCH1tRVCrM6oEfja6fR/bo5l6e4SkHRRSATh27UeN4f/ANC8U7tGIulmrISJVy9xuOkOdbYKbUb2MNM+nrw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.2.0.tgz",
+      "integrity": "sha512-lHHGay+YsffDn4M0bkkwezylBVHUpwwhtqte4LNPrFRCHy77X38+1PUe3neFb3glVTM+rbILtTN6FhO2djcOuQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",


### PR DESCRIPTION
Reverts dev-hato/hato-atama#168

以下のエラーでe2eテストが落ちることが多いので、cypressのアップデートをrevertします。

```
> cypress@7.3.0 postinstall /home/runner/work/hato-atama/hato-atama/test/e2e/node_modules/cypress
> node index.js --exec install

Installing Cypress (version: 7.3.0)

25l[10:48:15]  Downloading Cypress     [started]
[10:48:15]  Downloading Cypress     [failed]
25hThe Cypress App could not be downloaded.

Does your workplace require a proxy to be used to access the Internet? If so, you must configure the HTTP_PROXY environment variable before downloading Cypress. Read more: https://on.cypress.io/proxy-configuration

Otherwise, please check network connectivity and try again:

----------

URL: https://download.cypress.io/desktop/7.3.0?platform=linux&arch=x64
Error: Failed downloading the Cypress binary.
Response code: 404
Response message: Not Found

----------
```