### PR TITLE
appengineのruntimeのバージョンの更新

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: go114
+runtime: go115
 
 main: ./server
 


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/standard/go/runtime

goの場合はあまり関係なさそうには見えるけど、一応update