### PR TITLE
ブラウザ向けのCSSベンダープレフィックスを付与する

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,18 @@
     "build": "webpack --mode production",
     "dev": "webpack serve --mode development"
   },
+  "browserslist": [
+    "> 0.5%",
+    "> 0.5% in JP",
+    "last 2 versions",
+    "Firefox ESR",
+    "not dead",
+    "not ie<=11"
+  ],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "browserslist": "^4.16.6",
     "clean-webpack-plugin": "^3.0.0",
     "elm-webpack-loader": "^8.0.0",
     "html-loader": "^2.1.2",


### PR DESCRIPTION
フロントエンドのビルド時に以下のブラウザ向けのCSSベンダープレフィックスを付与するようにします。
* 世界シェア0.5%超
* 日本でのシェア0.5%超
* 最新2バージョン
* Firefox ESR (法人向け延長サポート版)
* サポートが終了していない
* IE11以下除く