### PR TITLE
ブラウザ向けのCSSベンダープレフィックスを付与する (コミット漏れ)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "browserslist": "^4.16.6",
         "clean-webpack-plugin": "^3.0.0",
         "elm-webpack-loader": "^8.0.0",
         "html-loader": "^2.1.2",


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/199 で `package-lock.json` をコミットし忘れていたのでコミットします。