### PR TITLE
dependabotがCIを回した場合でもwrite系のGitHub APIが実行できるようにする

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,10 +3,13 @@ name: format
 on:
   pull_request:
     branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
 
 jobs:
   format-go:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     env:
       DOCKER_BUILDKIT: 1
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  pull_request_target:
 
 env:
   DOCKER_COMPOSE_IMAGE_CACHE_DIR: /tmp/cache/docker-compose-image
@@ -69,7 +70,7 @@ jobs:
   create-pr-environment:
     runs-on: ubuntu-latest
     needs: deploy-app-engine
-    if: github.event_name == 'pull_request'
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/github-script@v4.0.2
         with:
@@ -89,6 +90,11 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
       - name: Cache docker image
         id: cache-docker-image
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-frontend:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     env:
       DOCKER_BUILDKIT: 1
     defaults:
@@ -20,6 +21,11 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
       - name: Get Node.js version
         id: get_node_version
         run: |
@@ -49,9 +55,15 @@ jobs:
 
   deploy-app-engine:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     needs: build-frontend
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
       - uses: google-github-actions/setup-gcloud@master
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
@@ -85,6 +97,7 @@ jobs:
 
   e2e-test-mini-docker-compose:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     env:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
@@ -142,11 +155,17 @@ jobs:
 
   e2e-test-all-docker-compose:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     env:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
       - name: Cache docker image
         id: cache-docker-image
         uses: actions/cache@v2
@@ -195,11 +214,17 @@ jobs:
 
   e2e-test-mini-prd:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     needs:
       - deploy-app-engine
       - e2e-test-mini-docker-compose
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
       - name: Cache node modules e2e
         uses: actions/cache@v2
         with:
@@ -247,7 +272,7 @@ jobs:
 
   pr-test-complete:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     needs:
       - create-pr-environment
       - e2e-test-mini-prd

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,15 +5,23 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
 
   workflow_dispatch:
 
 jobs:
   super-linter:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
 
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
 
       - name: Super-Linter
         uses: github/super-linter@v4.1.0


### PR DESCRIPTION
dependabotがCIを回した場合、write系のGitHub API (PRへのコメント等) が実行できずCIが失敗します。
そのため、dependabotがCIを実行する場合に限り、 `pull_request` トリガーの代わりに `pull_request_target` トリガーを使用します。

参考: https://simple-minds-think-alike.hatenablog.com/entry/dependabot-pull-request-fail