### PR TITLE
CIにおけるDockerのタグ名修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo 'TAG_NAME=${{github.head_ref}}' >> "$GITHUB_ENV"
+      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo 'TAG_NAME=${{github.head_ref}}' >> "$GITHUB_ENV"
+      - run: echo "$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
@@ -218,7 +218,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo 'TAG_NAME=${{github.head_ref}}' >> "$GITHUB_ENV"
+      - run: echo "$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")"' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo "$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
+      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
@@ -218,7 +218,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo "$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")"' >> "$GITHUB_ENV"
+      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")"' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")"' >> "$GITHUB_ENV"
+      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/274/checks?check_run_id=3226222553

```
invalid argument "ghcr.io/dev-hato/hato-atama/gcloud_datastore:dependabot/npm_and_yarn/frontend/webpack-5.48.0" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
Service 'gcloud_datastore' failed to build : Build failed
```

上記のエラーを修正します。
ブランチ名を意図的に様々な文字を含むものにしているので、これでCIが通ればおそらく問題なし。