### PR TITLE
Dependabotでcaniuse-liteの更新を明示的に指定してみる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,13 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "caniuse-lite"
+        dependency-type: "all"
     open-pull-requests-limit: 1
   - package-ecosystem: "npm"
     directory: "/test/e2e"


### PR DESCRIPTION
https://github.com/browserslist/browserslist#browsers-data-updating

>`npx browserslist@latest --update-db` updates `caniuse-lite` version in your npm, yarn or pnpm lock file.
>
>You need to do it regularly for two reasons:
>
>1. To use the latest browser’s versions and statistics in queries like `last 2 versions` or `>1%`. For example, if you created your project 2 years ago and did not update your dependencies, `last 1 version` will return 2 year old browsers.
>2. `caniuse-lite` deduplication: to synchronize version in different tools.

`browserslist` では `caniuse-lite` を常に最新の状態に保つことを推奨しています。
したがって、Dependabotを使って `caniuse-lite` を日次で更新できるようにしてみます、