### PR TITLE
Revert "Dependabotでcaniuse-liteの更新を明示的に指定してみる"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,13 +39,6 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "caniuse-lite"
-        dependency-type: "all"
     open-pull-requests-limit: 1
   - package-ecosystem: "npm"
     directory: "/test/e2e"


### PR DESCRIPTION
Reverts dev-hato/hato-atama#280

https://github.com/dev-hato/hato-atama/runs/3242643438

```
The property '#/updates/7' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
```

同じものについての記述は重複させられないとのこと。