### PR TITLE
secretlintの対象から.gitを除外する

### DIFF
--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Lint files
         id: lint
         run: |
-          result="$(find . -type f -not -path "./node_modules/*" -print0 | xargs -0 npx secretlint --maskSecrets 2>&1)" || true
+          result="$(find . -type f -not -path "./node_modules/*" -and -not -path "./.git/*" -print0 | xargs -0 npx secretlint --maskSecrets 2>&1)" || true
           echo "$result"
           result="${result//'%'/'%25'}"
           result="${result//$'\n'/'%0A'}"


### PR DESCRIPTION
secretlintで `.git/` 内も見ているので除外します。