### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -41,16 +41,20 @@ jobs:
           echo "::set-output name=result::$result"
       # 差分があったときは、コミットを作りpushする
       - name: Push
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
-          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/fix-format-${{github.event.pull_request.head.ref}}
+          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -60,8 +64,8 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "dev-hato:fix-format-${{github.event.pull_request.head.ref}}",
-              base: "${{github.event.pull_request.head.ref}}",
+              head: "dev-hato:fix-format-${HEAD_REF}",
+              base: "${HEAD_REF}",
               ...common_params
             }
             const pulls_list_params = {
@@ -96,18 +100,20 @@ jobs:
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result == '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const head_name = "fix-format-${{github.event.pull_request.head.ref}}"
+            const head_name = "fix-format-${HEAD_REF}"
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pulls_list_params = {
               head: "dev-hato:" + head_name,
-              base: "${{github.event.pull_request.head.ref}}",
+              base: "${HEAD_REF}",
               state: "open",
               ...common_params
             }

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -139,16 +139,20 @@ jobs:
           echo "::set-output name=diff::$(git diff)"
       # 差分があったときは、コミットを作りpushする
       - name: Push
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
-          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/fix-text-${{github.event.pull_request.head.ref}}
+          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -158,8 +162,8 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "dev-hato:fix-text-${{github.event.pull_request.head.ref}}",
-              base: "${{github.event.pull_request.head.ref}}",
+              head: "dev-hato:fix-text-${HEAD_REF}",
+              base: "${HEAD_REF}",
               ...common_params
             }
             const pulls_list_params = {
@@ -194,18 +198,20 @@ jobs:
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff == '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const head_name = "fix-text-${{github.event.pull_request.head.ref}}"
+            const head_name = "fix-text-${HEAD_REF}"
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pulls_list_params = {
               head: "dev-hato:" + head_name,
-              base: "${{github.event.pull_request.head.ref}}",
+              base: "${HEAD_REF}",
               state: "open",
               ...common_params
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
+      - run: echo "TAG_NAME=$(echo "${HEAD_REF}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
+        env:
+          HEAD_REF: ${{github.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
@@ -137,7 +139,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
+      - run: echo "TAG_NAME=$(echo "${HEAD_REF}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
+        env:
+          HEAD_REF: ${{github.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
@@ -218,7 +222,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo "TAG_NAME=$(echo "${{github.head_ref}}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
+      - run: echo "TAG_NAME=$(echo "${HEAF_REF}" | sed -e "s:/:-:g")" >> "$GITHUB_ENV"
+        env:
+          HEAF_REF: ${{github.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Super-Linter
-        uses: github/super-linter@v4.6.2
+        uses: github/super-linter@v4.7.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: test/e2e/cypress/integration/.*


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/335 をベースにsuper-linerをアップデートします。

`github.event.pull_request.head.ref` を直接コード内に埋め込むとインジェクション攻撃される危険があるため、環境変数を経由して埋め込むようにしています。
参考: https://securitylab.github.com/research/github-actions-untrusted-input/