### PR TITLE
README修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@
 ### 立ち上げ
 #### 編集するとhot reloadが走る、開発に適したバージョン
 ```sh
-TAG_NAME=`git symbolic-ref --short HEAD` docker-compose -f dev.docker-compose.yml up --build
+TAG_NAME=`git symbolic-ref --short HEAD | sed -e "s:/:-:g"` docker-compose -f dev.docker-compose.yml up --build
 ```
 
 #### 限りなく本番のapp engineに近い設定で動くバージョン
 ```sh
-TAG_NAME=`git symbolic-ref --short HEAD` docker-compose -f staging.docker-compose.yml up --build
+TAG_NAME=`git symbolic-ref --short HEAD | sed -e "s:/:-:g"` docker-compose -f staging.docker-compose.yml up --build
 ```


### PR DESCRIPTION
ブランチ名に `/` が含まれているとdockerの立ち上げに失敗するため、READMEに記載されているコマンドを修正します。