### PR TITLE
airのインストールコマンド修正

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 COPY server server
 
 WORKDIR /go/app/server
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app && go get -u github.com/cosmtrek/air
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app && go install github.com/cosmtrek/air@v1.27.3
 
 
 FROM scratch


### PR DESCRIPTION
```
go get: installing executables with 'go get' in module mode is deprecated.
	To adjust and download dependencies of the current module, use 'go get -d'.
	To install using requirements of the current module, use 'go install'.
	To install ignoring the current module, use 'go install' with a version,
	like 'go install example.com/cmd@latest'.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

`go get` は非推奨なため `go install` を使用するようにします。
また、それに合わせてインストール時にairのバージョンを指定するようにします。