### PR TITLE
CIでのNode.jsのバージョン取得時に.node-versionを使用する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,7 @@ jobs:
       - name: Get Node.js version
         id: get_node_version
         run: |
-          image_name=hato_atama_frontend_build
-          docker build -t "${image_name}" --target build -f Dockerfile ..
-          node_version=$(docker run ${image_name} sh -c "node --version | sed -e 's/^v//g'")
+          node_version=$(cat .node-version)
           echo "Node.js version:" "${node_version}"
           echo "::set-output name=node_version::${node_version}"
       - uses: actions/setup-node@v2

--- a/.github/workflows/resource-update.yml
+++ b/.github/workflows/resource-update.yml
@@ -21,9 +21,7 @@ jobs:
       - name: Get Node.js version
         id: get_node_version
         run: |
-          image_name=hato_atama_frontend_build
-          docker build -t "${image_name}" --target build -f Dockerfile ..
-          node_version=$(docker run ${image_name} sh -c "node --version | sed -e 's/^v//g'")
+          node_version=$(cat .node-version)
           echo "Node.js version:" "${node_version}"
           echo "::set-output name=node_version::${node_version}"
       - uses: actions/setup-node@v2
@@ -61,9 +59,7 @@ jobs:
       - name: Get Node.js version
         id: get_node_version
         run: |
-          image_name=hato_atama_frontend_build
-          docker build -t "${image_name}" --target build -f ../../frontend/Dockerfile ../..
-          node_version=$(docker run ${image_name} sh -c "node --version | sed -e 's/^v//g'")
+          node_version=$(cat .node-version)
           echo "Node.js version:" "${node_version}"
           echo "::set-output name=node_version::${node_version}"
       - uses: actions/setup-node@v2

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -22,7 +22,6 @@ jobs:
         run: echo "::set-output name=branch_name::$(echo '${{ matrix.directory }}' | sed -e 's:/:-:g')"
       - name: Get Node.js version
         id: get_node_version
-        working-directory: frontend
         run: |
           node_version=$(cat .node-version)
           echo "Node.js version:" "${node_version}"

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -24,9 +24,7 @@ jobs:
         id: get_node_version
         working-directory: frontend
         run: |
-          image_name=hato_atama_frontend_build
-          docker build -t "${image_name}" --target build -f Dockerfile ..
-          node_version=$(docker run ${image_name} sh -c "node --version | sed -e 's/^v//g'")
+          node_version=$(cat .node-version)
           echo "Node.js version:" "${node_version}"
           echo "::set-output name=node_version::${node_version}"
       - uses: actions/setup-node@v2


### PR DESCRIPTION
CIでNode.jsのバージョンを取得する際に `.node-version` を使うようにします。
これにより、CIの実行時間を削減できると考えられます。