### PR TITLE
リリース系のCI実行前にbotによる実行かチェックするCI追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,7 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
     permissions:
       packages: write
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,15 @@ on:
   pull_request:
 
 jobs:
+  check_bot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check bot
+        run: |
+          if("${{github.event.pull_request.user.login}}" === "dependabot[bot]") {
+            exit 1
+          }
+
   build-frontend:
     runs-on: ubuntu-latest
     env:
@@ -14,6 +23,7 @@ jobs:
     defaults:
       run:
         working-directory: frontend
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Get Node.js version
@@ -87,6 +97,7 @@ jobs:
     strategy:
       matrix:
         browser: [ "chrome", "chromium", "firefox", "electron" ]
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
@@ -126,6 +137,7 @@ jobs:
     strategy:
       matrix:
         browser: [ "chrome", "chromium", "firefox", "electron" ]
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check bot
         run: |
-          if ["${{github.event.pull_request.user.login}}" = "dependabot[bot]" ]; then
+          if [ "${{github.event.pull_request.user.login}}" = "dependabot[bot]" ]; then
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: Check bot
         run: |
-          if("${{github.event.pull_request.user.login}}" === "dependabot[bot]") {
+          if ["${{github.event.pull_request.user.login}}" = "dependabot[bot]" ]; then
             exit 1
-          }
+          fi
 
   build-frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
リリース系のCIはdependabot等のbotによって実行された場合、権限の問題で失敗するので、これらのCIを実行する前にbotによる実行かをチェックするCIを追加します。