### PR TITLE
update-versionをmatrixを使わない形にする

### DIFF
--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -152,17 +152,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
-    strategy:
-      matrix:
-        directory: [ 'frontend', 'test/e2e', '.' ]
-    defaults:
-      run:
-        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v2
-      - name: Get branch name
-        id: get_branch_name
-        run: echo "::set-output name=branch_name::$(echo '${{ matrix.directory }}' | sed -e 's:/:-:g' | sed -e 's/\./root/g')"
       - name: Get Node.js version
         id: get_node_version
         working-directory: frontend
@@ -172,8 +163,11 @@ jobs:
           node_version=$(docker run ${image_name} sh -c "node --version | sed -e 's/^v//g'")
           echo "Node.js version:" "${node_version}"
           echo "::set-output name=node_version::${node_version}"
-      - name: Update version
-        run: echo "${{steps.get_node_version.outputs.node_version}}" > .node-version
+      - name: Update versions
+        run: |
+          for path in "frontend" "test/e2e" "."; do
+            echo "${{steps.get_node_version.outputs.node_version}}" > ${path}/.node-version
+          done
       # 差分があったときは差分を出力する
       - name: Show diff
         id: diff
@@ -190,7 +184,7 @@ jobs:
           git config user.email "hatohakaraage@example.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
-          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-version-${{ steps.get_branch_name.outputs.branch_name }}-${HEAD_REF}"
+          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-version-${HEAD_REF}"
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
@@ -206,7 +200,7 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "dev-hato:fix-version-${{ steps.get_branch_name.outputs.branch_name }}-" + HEAD_REF,
+              head: "dev-hato:fix-version-" + HEAD_REF,
               base: HEAD_REF,
               ...common_params
             }
@@ -219,7 +213,7 @@ jobs:
             github.pulls.list(pulls_list_params).then(list_res => {
               if (list_res.data.length === 0) {
                 const pulls_create_params = {
-                  title: "${{ matrix.directory }}の.node-versionを直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
+                  title: ".node-versionを直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
                   body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
                   ...pull_params
                 }
@@ -249,7 +243,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            const head_name = "fix-version-${{ steps.get_branch_name.outputs.branch_name }}-" + HEAD_REF
+            const head_name = "fix-version-" + HEAD_REF
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	golang.org/x/mod v0.5.0 // indirect
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff // indirect
-	golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 // indirect
+	golang.org/x/sys v0.0.0-20210915083310-ed5796bab164 // indirect
 	google.golang.org/api v0.51.0 // indirect
 	google.golang.org/genproto v0.0.0-20210726200206-e7812ac95cc0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=
-golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210915083310-ed5796bab164 h1:7ZDGnxgHAMw7thfC5bEos0RDAccZKxioiWBhfIe+tvw=
+golang.org/x/sys v0.0.0-20210915083310-ed5796bab164/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
CI `update-version` ではmatrixを使っていますが、9割方同じ処理なので一つにまとめます。