### PR TITLE
リリース後のApp Engineのバージョン削除のCI修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,9 @@ jobs:
 
   remove-app-engine-past-versions:
     runs-on: ubuntu-latest
+    needs:
+      - migrating-traffic
+    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.2.1
@@ -253,7 +256,7 @@ jobs:
         uses: actions/github-script@v4.1
         id: get_run_numbers
         env:
-          HEAD_REF: master
+          HEAD_REF: ${{github.head_ref}}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -283,7 +286,7 @@ jobs:
                 console.log("call actions.listWorkflowRuns:")
                 console.log(list_workflow_runs_params)
                 const runs_res = await github.actions.listWorkflowRuns(list_workflow_runs_params)
-                return runs_res.data.workflow_runs.filter(run => run.run_number < 974).map(run => {
+                return runs_res.data.workflow_runs.filter(run => run.run_number < ${{github.run_number}}).map(run => {
                   if (run.status !== 'completed') {
                     return running
                   }
@@ -313,7 +316,7 @@ jobs:
       - name: Remove app engine versions
         run: |
           for run_number in $(echo "${{steps.get_run_numbers.outputs.result}}" | jq ".[]"); do
-            echo gcloud app versions delete --service=default "v${run_number}"
+            gcloud app versions delete --service=default "v${run_number}"
           done
 
   pr-test-complete-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,11 +273,7 @@ jobs:
               console.log("call actions.listRepoWorkflows:")
               console.log(common_params)
               const workflows_res = await github.actions.listRepoWorkflows(common_params)
-              const run_numbers = await Promise.all(workflows_res.data.workflows.map(async workflow => {
-                if (workflow.name !== 'release') {
-                  return
-                }
-
+              const run_numbers = await Promise.all(workflows_res.data.workflows.filter(workflow => workflow.name === 'release').map(async workflow => {
                 const list_workflow_runs_params = {
                   workflow_id: workflow.id,
                   branch: HEAD_REF,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,9 +242,6 @@ jobs:
 
   remove-app-engine-past-versions:
     runs-on: ubuntu-latest
-    needs:
-      - migrating-traffic
-    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.2.1
@@ -256,7 +253,7 @@ jobs:
         uses: actions/github-script@v4.1
         id: get_run_numbers
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: master
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -286,7 +283,7 @@ jobs:
                 console.log("call actions.listWorkflowRuns:")
                 console.log(list_workflow_runs_params)
                 const runs_res = await github.actions.listWorkflowRuns(list_workflow_runs_params)
-                return runs_res.data.workflow_runs.filter(run => run.run_number < ${{github.run_number}}).map(run => {
+                return runs_res.data.workflow_runs.filter(run => run.run_number < 974).map(run => {
                   if (run.status !== 'completed') {
                     return running
                   }
@@ -316,7 +313,7 @@ jobs:
       - name: Remove app engine versions
         run: |
           for run_number in $(echo "${{steps.get_run_numbers.outputs.result}}" | jq ".[]"); do
-            gcloud app versions delete --service=default "v${run_number}"
+            echo gcloud app versions delete --service=default "v${run_number}"
           done
 
   pr-test-complete-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,9 @@ jobs:
 
   remove-app-engine-past-versions:
     runs-on: ubuntu-latest
+    needs:
+      - migrating-traffic
+    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.2.1
@@ -279,7 +282,7 @@ jobs:
                 console.log("call actions.listWorkflowRuns:")
                 console.log(list_workflow_runs_params)
                 const runs_res = await github.actions.listWorkflowRuns(list_workflow_runs_params)
-                return runs_res.data.workflow_runs.filter(run => run.run_number < 974).map(run => {
+                return runs_res.data.workflow_runs.filter(run => run.run_number < ${{github.run_number}}).map(run => {
                   if (run.status !== 'completed') {
                     return running
                   }
@@ -309,7 +312,7 @@ jobs:
       - name: Remove app engine versions
         run: |
           for run_number in $(echo "${{steps.get_run_numbers.outputs.result}}" | jq ".[]"); do
-            echo gcloud app versions delete --service=default "v${run_number}"
+            gcloud app versions delete --service=default "v${run_number}"
           done
 
   pr-test-complete-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,9 +242,6 @@ jobs:
 
   remove-app-engine-past-versions:
     runs-on: ubuntu-latest
-    needs:
-      - migrating-traffic
-    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.2.1
@@ -282,7 +279,7 @@ jobs:
                 console.log("call actions.listWorkflowRuns:")
                 console.log(list_workflow_runs_params)
                 const runs_res = await github.actions.listWorkflowRuns(list_workflow_runs_params)
-                return runs_res.data.workflow_runs.filter(run => run.run_number < ${{github.run_number}}).map(run => {
+                return runs_res.data.workflow_runs.filter(run => run.run_number < 974).map(run => {
                   if (run.status !== 'completed') {
                     return running
                   }
@@ -312,7 +309,7 @@ jobs:
       - name: Remove app engine versions
         run: |
           for run_number in $(echo "${{steps.get_run_numbers.outputs.result}}" | jq ".[]"); do
-            gcloud app versions delete --service=default "v${run_number}"
+            echo gcloud app versions delete --service=default "v${run_number}"
           done
 
   pr-test-complete-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,7 +256,7 @@ jobs:
         uses: actions/github-script@v4.1
         id: get_run_numbers
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: master
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,11 +286,7 @@ jobs:
                 console.log("call actions.listWorkflowRuns:")
                 console.log(list_workflow_runs_params)
                 const runs_res = await github.actions.listWorkflowRuns(list_workflow_runs_params)
-                return runs_res.data.workflow_runs.map(run => {
-                  if (${{github.run_number}} <= run.run_number) {
-                    return
-                  }
-
+                return runs_res.data.workflow_runs.filter(run => run.run_number < ${{github.run_number}}).map(run => {
                   if (run.status !== 'completed') {
                     return running
                   }


### PR DESCRIPTION
map内で行っていた絞り込み処理をfilterで行うようにします。
また、当該のworkflowより前のバージョンを全削除していたので、対象のブランチを直接指定するようにします。

CI実行時のログ: https://github.com/dev-hato/hato-atama/runs/3682276414