### PR TITLE
actions/github-scriptアップデート

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -68,7 +68,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -90,7 +90,7 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
         uses: actions/github-script@v5
@@ -105,7 +105,7 @@ jobs:
               assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v5

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -51,7 +51,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
@@ -72,7 +72,7 @@ jobs:
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
@@ -93,7 +93,7 @@ jobs:
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -108,7 +108,7 @@ jobs:
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result == '' }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -128,7 +128,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
 
             for (const pull of pulls) {
               const pulls_update_params = {
@@ -137,13 +137,13 @@ jobs:
                 ...common_params
               }
               console.log("call pulls.update:", pulls_update_params)
-              await github.pulls.update(pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
               console.log("call git.deleteRef:", git_deleteRef_params)
-              await github.git.deleteRef(git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
             }
       - name: Exit
         if: ${{ steps.diff.outputs.result != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            await github.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -272,7 +272,7 @@ jobs:
 
             for (let i = 0; i < retry_count; i++) {
               console.log("call actions.listRepoWorkflows:", common_params)
-              const workflows = await github.paginate(github.actions.listRepoWorkflows, common_params)
+              const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, common_params)
               const run_numbers = await Promise.all(workflows.filter(workflow => workflow.name === 'release').map(async workflow => {
                 const list_workflow_runs_params = {
                   workflow_id: workflow.id,
@@ -280,7 +280,7 @@ jobs:
                   ...common_params
                 }
                 console.log("call actions.listWorkflowRuns:", list_workflow_runs_params)
-                const runs = await github.paginate(github.actions.listWorkflowRuns, list_workflow_runs_params)
+                const runs = await github.paginate(github.rest.actions.listWorkflowRuns, list_workflow_runs_params)
                 return runs.filter(run => run.run_number < ${{github.run_number}}).map(run => {
                   if (run.status !== 'completed') {
                     return running

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     needs: deploy-app-engine
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/github-script@v4.1
+      - uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -253,7 +253,7 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: Get run numbers
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         id: get_run_numbers
         env:
           HEAD_REF: master

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -16,7 +16,7 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: Get run numbers
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         id: get_run_numbers
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -35,7 +35,7 @@ jobs:
 
             for (let i = 0; i < retry_count; i++) {
               console.log("call actions.listRepoWorkflows:", common_params)
-              const workflows = await github.paginate(github.actions.listRepoWorkflows, common_params)
+              const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, common_params)
               const run_numbers = await Promise.all(workflows.filter(workflow => workflow.name === 'release').map(async workflow => {
                 const list_workflow_runs_params = {
                   workflow_id: workflow.id,
@@ -43,7 +43,7 @@ jobs:
                   ...common_params
                 }
                 console.log("call actions.listWorkflowRuns:", list_workflow_runs_params)
-                const runs = await github.paginate(github.actions.listWorkflowRuns, list_workflow_runs_params)
+                const runs = await github.paginate(github.rest.actions.listWorkflowRuns, list_workflow_runs_params)
                 return runs.map(run => {
                   if (run.status !== 'completed') {
                     return running

--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -58,7 +58,7 @@ jobs:
              repo: context.repo.repo
             }
             console.log("call issues.listComments:", issues_listComments_params)
-            const issue_comments = (await github.paginate(github.issues.listComments, issues_listComments_params)).filter(
+            const issue_comments = (await github.paginate(github.rest.issues.listComments, issues_listComments_params)).filter(
               issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('secretlintの')
             )
 
@@ -69,7 +69,7 @@ jobs:
                 repo: context.repo.repo
               }
               console.log("call issues.deleteComment:", issues_deleteComment_params)
-              await github.issues.deleteComment(issues_deleteComment_params)
+              await github.rest.issues.deleteComment(issues_deleteComment_params)
             }
 
             const result = `${{steps.lint.outputs.result}}`
@@ -80,7 +80,7 @@ jobs:
               body: "secretlintのLint結果だよ！🕊🕊🕊\n```\n"+result+"\n```"
             }
             console.log("call issues.createComment:", issues_createComment_params)
-            await github.issues.createComment(issues_createComment_params)
+            await github.rest.issues.createComment(issues_createComment_params)
       - name: Exit
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository && steps.lint.outcome == 'failure' }}
         run: exit 1

--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -48,7 +48,7 @@ jobs:
       # lint結果をコメントに残す
       - name: Lint Comment
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.lint.outputs.result != '' }}
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -48,7 +48,7 @@ jobs:
       # lint結果をコメントに残す
       - name: Lint Comment
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.lint.outputs.result != '' }}
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -138,7 +138,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
@@ -159,7 +159,7 @@ jobs:
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' && steps.get_pull_requests.outputs.result == 0 }}
@@ -180,7 +180,7 @@ jobs:
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ steps.show_diff.outputs.diff != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -195,7 +195,7 @@ jobs:
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff == '' }}

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -155,7 +155,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -177,7 +177,7 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
         uses: actions/github-script@v5
@@ -192,7 +192,7 @@ jobs:
               assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v5
@@ -215,7 +215,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
 
             for (const pull of pulls) {
               const pulls_update_params = {
@@ -224,13 +224,13 @@ jobs:
                 ...common_params
               }
               console.log("call pulls.update:", pulls_update_params)
-              await github.pulls.update(pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
               console.log("call git.deleteRef:", git_deleteRef_params)
-              await github.git.deleteRef(git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
             }
       - name: Exit
         if: ${{ steps.show_diff.outputs.diff != '' }}

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -58,7 +58,7 @@ jobs:
              repo: context.repo.repo
             }
             console.log("call issues.listComments:", issues_listComments_params)
-            const issue_comments = (await github.paginate(github.issues.listComments, issues_listComments_params)).filter(
+            const issue_comments = (await github.paginate(github.rest.issues.listComments, issues_listComments_params)).filter(
               issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('日本語の')
             )
 
@@ -69,7 +69,7 @@ jobs:
                   repo: context.repo.repo
                 }
                 console.log("call issues.deleteComment:", issues_deleteComment_params)
-                await github.issues.deleteComment(issues_deleteComment_params)
+                await github.rest.issues.deleteComment(issues_deleteComment_params)
             }
 
             const result = `${{steps.lint.outputs.result}}`
@@ -80,7 +80,7 @@ jobs:
               body: "日本語のLint結果だよ！🕊🕊🕊\n```\n"+result+"\n```"
             }
             console.log("call issues.createComment:", issues_createComment_params)
-            await github.issues.createComment(issues_createComment_params)
+            await github.rest.issues.createComment(issues_createComment_params)
       - name: Exit
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository && steps.lint.outcome == 'failure' }}
         run: exit 1

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -53,7 +53,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-package-${{ steps.get_branch_name.outputs.branch_name }}-${HEAD_REF}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
@@ -74,7 +74,7 @@ jobs:
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
@@ -95,7 +95,7 @@ jobs:
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -110,7 +110,7 @@ jobs:
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result == '' }}
@@ -191,7 +191,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-version-${HEAD_REF}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
@@ -212,7 +212,7 @@ jobs:
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
@@ -233,7 +233,7 @@ jobs:
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -248,7 +248,7 @@ jobs:
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result == '' }}

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -70,7 +70,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -92,7 +92,7 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
         uses: actions/github-script@v5
@@ -107,7 +107,7 @@ jobs:
               assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v5

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -130,7 +130,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:",pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
 
             for (const pull of pulls) {
               const pulls_update_params = {
@@ -140,13 +140,13 @@ jobs:
               }
               console.log("call pulls.update:")
               console.log(pulls_update_params)
-              await github.pulls.update(pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
               console.log("call git.deleteRef:", git_deleteRef_params)
-              await github.git.deleteRef(git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
             }
       - name: Exit
         if: ${{ steps.diff.outputs.result != '' }}
@@ -208,7 +208,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -230,7 +230,7 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
         uses: actions/github-script@v5
@@ -245,7 +245,7 @@ jobs:
               assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v5
@@ -268,7 +268,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
 
             for (const pull of pulls) {
               const pulls_update_params = {
@@ -277,13 +277,13 @@ jobs:
                 ...common_params
               }
               console.log("call pulls.update:", pulls_update_params)
-              await github.pulls.update(pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
               console.log("call git.deleteRef:", git_deleteRef_params)
-              await github.git.deleteRef(git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
             }
       - name: Exit
         if: ${{ steps.diff.outputs.result != '' }}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/labstack/echo/v4 v4.6.0
-	golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 // indirect
+	golang.org/x/sys v0.0.0-20210925032602-92d5a993a665 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 h1:c20P3CcPbopVp2f7099WLOqSNKURf30Z0uq66HpijZY=
-golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210925032602-92d5a993a665 h1:QOQNt6vCjMpXE7JSK5VvAzJC1byuN3FgTNSBwf+CJgI=
+golang.org/x/sys v0.0.0-20210925032602-92d5a993a665/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/424 をベースに `actions/github-script` をアップデートします。
なお、 `actions/github-script v5` ではREST API呼び出し時に `github.rest.~` を使う必要があるため修正しています。
参考: https://github.com/actions/github-script#breaking-changes-in-v5