### PR TITLE
該当するバージョンがない場合はApp Engineのバージョン削除を行わないようにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,7 @@ jobs:
 
             return result.join(' ')
       - name: Remove app engine versions
+        if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: gcloud app versions delete --service=default ${{steps.get_run_numbers.outputs.result}}
 
   pr-test-complete-check:

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -72,4 +72,5 @@ jobs:
 
             return result.join(' ')
       - name: Remove app engine versions
+        if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: gcloud app versions delete --service=default ${{steps.get_run_numbers.outputs.result}}


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/runs/3704689401?check_suite_focus=true

```
ERROR: (gcloud.app.versions.delete) argument VERSIONS [VERSIONS ...]: Must be specified.
```

該当するバージョンがない状態でApp Engineのバージョンを削除しようとするとエラーになるので、このような場合は削除を行わないようにします。