### PR TITLE
リリース系のCI実行前にbotによる実行かチェックするCI追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check bot
         run: |
-          if [ "${{github.event.pull_request.user.login}}" = "dependabot[bot]" ]; then
+          if [ "${{github.actor}}" = "dependabot[bot]" ]; then
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,21 @@ on:
   pull_request:
 
 jobs:
+  check_bot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check bot
+        run: |
+          if [ "${{github.event.pull_request.user.login}}" = "dependabot[bot]" ]; then
+            exit 1
+          fi
+
   build-frontend:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frontend
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Get Node.js version
@@ -85,6 +95,7 @@ jobs:
     strategy:
       matrix:
         browser: [ "chrome", "chromium", "firefox", "electron" ]
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
@@ -124,6 +135,7 @@ jobs:
     strategy:
       matrix:
         browser: [ "chrome", "chromium", "firefox", "electron" ]
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
@@ -207,6 +219,7 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
     permissions:
       packages: write
+    needs: check_bot
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
リリース系のCIはdependabot等のbotによって実行された場合、権限の問題で失敗するので、これらのCIを実行する前にbotによる実行かをチェックするCIを追加します。
https://github.com/dev-hato/hato-atama/pull/376 と違い、 `github.event.pull_request.user.login` ではなく `github.actor` の値でbotかを判別するようにしています。