### PR TITLE
CI update-package でcaniuse-liteのアップデートも行う

### DIFF
--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -34,7 +34,9 @@ jobs:
           key: npm-cache-${{ steps.get_branch_name.outputs.branch_name }}-${{ hashFiles('**/${{ matrix.directory }}/package-lock.json') }}
           restore-keys: |
             npm-cache-${{ steps.get_branch_name.outputs.branch_name }}-
-      - run: npm install
+      - run: |
+          npm install
+          npx browserslist@latest --update-db
       # 差分があったときは差分を出力する
       - name: Show diff
         id: diff

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "devDependencies": {
         "browserslist": "^4.17.3",
-        "caniuse-lite": "1.0.30001260",
         "clean-webpack-plugin": "^4.0.0",
         "elm-webpack-loader": "^8.0.0",
         "html-loader": "^2.1.2",
@@ -678,16 +677,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/browserslist/node_modules/caniuse-lite": {
-      "version": "1.0.30001264",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
-      "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -733,13 +722,10 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001260",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
-      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "version": "1.0.30001264",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
+      "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
       "dev": true,
-      "dependencies": {
-        "nanocolors": "^0.1.0"
-      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -2962,15 +2948,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
-    },
-    "node_modules/nanocolors": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.6.tgz",
-      "integrity": "sha512-2pvTw6vYRaBLGir2xR7MxaJtyWkrn+C53EpW8yPotG+pdAwBvt0Xwk4VJ6VHLY0aLthVZPvDfm9TdZvrvAm5UQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.2",
@@ -5566,14 +5543,6 @@
         "escalade": "^3.1.1",
         "node-releases": "^1.1.77",
         "picocolors": "^0.2.1"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001264",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
-          "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
-          "dev": true
-        }
       }
     },
     "buffer-from": {
@@ -5615,13 +5584,10 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001260",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
-      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
-      "dev": true,
-      "requires": {
-        "nanocolors": "^0.1.0"
-      }
+      "version": "1.0.30001264",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
+      "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -7321,12 +7287,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-      "dev": true
-    },
-    "nanocolors": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.6.tgz",
-      "integrity": "sha512-2pvTw6vYRaBLGir2xR7MxaJtyWkrn+C53EpW8yPotG+pdAwBvt0Xwk4VJ6VHLY0aLthVZPvDfm9TdZvrvAm5UQ==",
       "dev": true
     },
     "negotiator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
   "license": "ISC",
   "devDependencies": {
     "browserslist": "^4.17.3",
-    "caniuse-lite": "^1.0.30001260",
     "clean-webpack-plugin": "^4.0.0",
     "elm-webpack-loader": "^8.0.0",
     "html-loader": "^2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "devDependencies": {
     "browserslist": "^4.17.3",
-    "caniuse-lite": "1.0.30001260",
+    "caniuse-lite": "^1.0.30001260",
     "clean-webpack-plugin": "^4.0.0",
     "elm-webpack-loader": "^8.0.0",
     "html-loader": "^2.1.2",


### PR DESCRIPTION
Dependabotでアップデートするようにしていても、 `caniuse-lite` のバージョンが最新にならないケースがあるので、CI `update-package` で `npx browserslist@latest --update-db` を実行するようにします。
参考: https://github.com/browserslist/browserslist#browsers-data-updating