### PR TITLE
CIによるコミットをGitHub Actionsによるコミット扱いにする

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -46,8 +46,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"

--- a/.github/workflows/resource-update.yml
+++ b/.github/workflows/resource-update.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           commit-message: Update frontend
-          committer: GitHub <noreply@github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: ${{ github.event.inputs.base-branch-name }}-update-frontend
@@ -76,7 +76,7 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           commit-message: Update test/e2e
-          committer: GitHub <noreply@github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: ${{ github.event.inputs.base-branch-name }}-update-test-e2e
@@ -117,7 +117,7 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           commit-message: Update go
-          committer: GitHub <noreply@github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: ${{ github.event.inputs.base-branch-name }}-update-go

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -132,8 +132,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"

--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -52,8 +52,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-package-${{ steps.get_branch_name.outputs.branch_name }}-${HEAD_REF}"
@@ -193,8 +193,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-version-${HEAD_REF}"

--- a/.github/workflows/update_pre_commit_config.yml
+++ b/.github/workflows/update_pre_commit_config.yml
@@ -55,8 +55,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .pre-commit-config.yaml
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-version-pre-commit-config-${HEAD_REF}"


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/commit/78ba681446949fdd6fb4b7cfbcc470e6029c6eb3

```
Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
```

CIによるコミットのCommitterを上記のメールアドレスに変更することで、CIによるコミットをGitHub Actionsによるコミット扱いにしてみます。