### PR TITLE
App Engineへのデプロイ時にデプロイ完了までwaitするようにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           # 最大10分待つ
           for i in $(seq 600); do
             serving_status=$(gcloud app versions describe "v${{github.run_number}}" --service "default" --format "value(servingStatus)")
-            echo "servingStatus: ${serving_status}"
+            echo "${i}: servingStatus: ${serving_status}"
           
             if [ "${serving_status}" = "SERVING" ]; then
               exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,22 @@ jobs:
           project_id: hato-atama
           promote: false
           version: "v${{github.run_number}}"
+      - name: Wait for the deployment to complete
+        run: |
+          # 最大10分待つ
+          for i in $(seq 600); do
+            serving_status=$(gcloud app versions describe "v${{github.run_number}}" --service "default" --format "value(servingStatus)")
+            echo "servingStatus: ${serving_status}"
+          
+            if [ "${serving_status}" = "SERVING" ]; then
+              exit 0
+            fi
+          
+            sleep 1
+          done
+          
+          exit 1
+
 
   create-pr-environment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/runs/4613125129?check_suite_focus=true

App engineへのデプロイ直後のE2Eテストが落ちることがあるので、デプロイしたバージョンの `servingStatus` が `SERVING` になるまで最大10分間waitするようにします。