### PR TITLE
HTML修正

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -66,7 +66,7 @@ view model =
         nowURL =
             model.url
     in
-    { title = ""
+    { title = "hato-atama"
     , body =
         [ let
             shortURLBase =

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <meta charset="UTF-8">
   <title>hato-atama</title>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Main</title>
+  <title>hato-atama</title>
   <style>body { padding: 0; margin: 0; }</style>
 </head>
 


### PR DESCRIPTION
https://googlechrome.github.io/lighthouse/viewer/?psiurl=https%3A%2F%2Fhato-atama.an.r.appspot.com%2F&strategy=mobile&category=performance&category=accessibility&category=best-practices&category=seo&category=pwa&utm_source=lh-chrome-ext

>Document doesn't have a <title> element
>The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. 

><html> element does not have a [lang] attribute
>If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. 

lighthouseによる上記の指摘を修正します。