### PR TITLE
robots.txt追加

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,5 +14,6 @@ FROM scratch
 WORKDIR /app
 
 COPY --from=build /go/app/server/app .
+COPY --from=build /go/app/server/public/ .
 
 ENTRYPOINT ["./app"]

--- a/server/main.go
+++ b/server/main.go
@@ -86,7 +86,7 @@ func createServer() (e *echo.Echo) {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Gzip())
 
-	e.Static("/robots.txt", "./public/robots.txt")
+	e.File("/robots.txt", "./public/robots.txt")
 
 	api := e.Group("/api")
 	api.POST("/create", createShortURL)

--- a/server/main.go
+++ b/server/main.go
@@ -86,6 +86,8 @@ func createServer() (e *echo.Echo) {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Gzip())
 
+	e.Static("/robots.txt", "./public/robots.txt")
+
 	api := e.Group("/api")
 	api.POST("/create", createShortURL)
 

--- a/server/public/robots.txt
+++ b/server/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /l/


### PR DESCRIPTION
https://googlechrome.github.io/lighthouse/viewer/?psiurl=https%3A%2F%2Fhato-atama.an.r.appspot.com%2Frobots.txt&strategy=mobile&category=performance&category=accessibility&category=best-practices&category=seo&category=pwa&utm_source=lh-chrome-ext

>robots.txt is not valid 1 error found
>If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed.

`robots.txt` を追加します。
短縮URL ( `/l/~` ) はクロール対象から外しています。