### PR TITLE
指定バージョン以外でもnpm installできるようにする

### DIFF
--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -202,24 +202,15 @@ jobs:
         run: |
           image_name=hato_atama_frontend_build
           docker build -t "${image_name}" --target build -f Dockerfile ..
-          DOCKER_CMD="node --version && npm --version"
-          mapfile -t result < <(docker run ${image_name} sh -c "${DOCKER_CMD}")
-          node_version="${result[0]//v/}"
-          npm_version=${result[1]}
+          DOCKER_CMD="node --version | sed -e 's/^v//g'"
+          node_version=$(docker run ${image_name} sh -c "${DOCKER_CMD}")
           echo "Node.js version:" "${node_version}"
-          echo "npm version:" "${npm_version}"
           echo "::set-output name=node_version::${node_version}"
-          echo "::set-output name=npm_version::${npm_version}"
       - name: Update versions
         run: |
           NODE_VERSION="${{steps.get_node_version.outputs.node_version}}"
-          NPM_VERSION="${{steps.get_node_version.outputs.npm_version}}"
           for path in "frontend" "test/e2e" "."; do
             echo "${NODE_VERSION}" > ${path}/.node-version
-            NODE_PATTERN="s/\"node\": \".*\"/\"node\": \"^${NODE_VERSION}\"/g"
-            sed -i -e "${NODE_PATTERN}" ${path}/package.json
-            NPM_PATTERN="s/\"npm\": \".*\"/\"npm\": \"^${NPM_VERSION}\"/g"
-            sed -i -e "${NPM_PATTERN}" ${path}/package.json
           done
       # 差分があったときは差分を出力する
       - name: Show diff

--- a/.github/workflows/update_pre_commit_config.yml
+++ b/.github/workflows/update_pre_commit_config.yml
@@ -12,10 +12,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v2.5.1
-        with:
-          node-version-file: .node-version
-          cache: npm
       - name: Install packages
         run: npm install js-yaml
       - name: Update .pre-commit-config.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,6 @@ FROM node:17.3.0-alpine3.12 as build
 
 WORKDIR /usr/src/app
 
-COPY .npmrc .
 COPY frontend/package*.json ./
 RUN npm install
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,10 +18,6 @@
         "webpack": "^5.67.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.7.3"
-      },
-      "engines": {
-        "node": "^17.3.0",
-        "npm": "^8.3.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,9 +28,5 @@
     "webpack": "^5.67.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.3"
-  },
-  "engines": {
-    "node": "^17.3.0",
-    "npm": "^8.3.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,6 @@
         "textlint-rule-preset-ja-technical-writing": "^7.0.0",
         "textlint-rule-preset-jtf-style": "^2.3.12",
         "textlint-rule-spellcheck-tech-word": "^5.0.0"
-      },
-      "engines": {
-        "node": "^17.3.0",
-        "npm": "^8.3.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,5 @@
   },
   "resolutions": {
     "ansi-regex": "^5.0.1"
-  },
-  "engines": {
-    "node": "^17.3.0",
-    "npm": "^8.3.0"
   }
 }

--- a/test/e2e/.npmrc
+++ b/test/e2e/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -11,10 +11,6 @@
       "devDependencies": {
         "cypress": "^9.0.0",
         "eslint-plugin-cypress": "^2.11.3"
-      },
-      "engines": {
-        "node": "^17.3.0",
-        "npm": "^8.3.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -11,9 +11,5 @@
   "devDependencies": {
     "cypress": "^9.0.0",
     "eslint-plugin-cypress": "^2.11.3"
-  },
-  "engines": {
-    "node": "^17.3.0",
-    "npm": "^8.3.0"
   }
 }


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/network/updates/273625657

```
updater | <job_273625657> npm ERR! notsup Required: {"node":"^17.3.0","npm":"^8.3.0"}
updater | <job_273625657> npm ERR! notsup Actual:   {"npm":"7.21.0","node":"v14.18.3"}
```

Dependabotで対応しているNode.jsのバージョンと指定しているバージョンがずれてDependabotが失敗してしまうため、指定バージョン以外でもnpm installできるようにします。