### PR TITLE
非推奨のtextlintルール削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "textlint-rule-prefer-tari-tari": "^1.0.3",
     "textlint-rule-preset-ja-spacing": "^2.2.0",
     "textlint-rule-preset-ja-technical-writing": "^7.0.0",
-    "textlint-rule-preset-jtf-style": "^2.3.12",
-    "textlint-rule-spellcheck-tech-word": "^5.0.0"
+    "textlint-rule-preset-jtf-style": "^2.3.12"
   },
   "resolutions": {
     "ansi-regex": "^5.0.1"


### PR DESCRIPTION
https://github.com/azu/textlint-rule-spellcheck-tech-word

>Deprecated: [Proofdict](https://github.com/proofdict/proofdict)を使っているためメンテナンスしていません。

とのことなので `textlint-rule-spellcheck-tech-word` を削除します。