### PR TITLE
指定バージョン以外でnpm installできないようにする

### DIFF
--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -202,15 +202,22 @@ jobs:
         run: |
           image_name=hato_atama_frontend_build
           docker build -t "${image_name}" --target build -f Dockerfile ..
-          DOCKER_CMD="node --version | sed -e 's/^v//g'"
-          node_version=$(docker run ${image_name} sh -c "${DOCKER_CMD}")
+          DOCKER_CMD="node --version && npm --version"
+          mapfile -t result < <(docker run ${image_name} sh -c "${DOCKER_CMD}")
+          node_version="${result[0]//v/}"
+          npm_version=${result[1]}
           echo "Node.js version:" "${node_version}"
+          echo "npm version:" "${npm_version}"
           echo "::set-output name=node_version::${node_version}"
+          echo "::set-output name=npm_version::${npm_version}"
       - name: Update versions
         run: |
           NODE_VERSION="${{steps.get_node_version.outputs.node_version}}"
+          NPM_VERSION="${{steps.get_node_version.outputs.npm_version}}"
           for path in "frontend" "test/e2e" "."; do
             echo "${NODE_VERSION}" > ${path}/.node-version
+            NPM_PATTERN="s/\"npm\": \".*\"/\"npm\": \"^${NPM_VERSION}\"/g"
+            sed -i -e "${NPM_PATTERN}" ${path}/package.json
           done
       # 差分があったときは差分を出力する
       - name: Show diff

--- a/.github/workflows/update_pre_commit_config.yml
+++ b/.github/workflows/update_pre_commit_config.yml
@@ -12,6 +12,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v2.5.1
+        with:
+          node-version-file: .node-version
+          cache: npm
       - name: Install packages
         run: npm install js-yaml
       - name: Update .pre-commit-config.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,7 @@ FROM node:17.6.0-bullseye-slim as build
 
 WORKDIR /usr/src/app
 
+COPY .npmrc .
 COPY frontend/package*.json ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,10 @@
         "webpack": "^5.69.1",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.7.4"
+      },
+      "engines": {
+        "node": ">=16.14.0 <18.0.0",
+        "npm": "^8.5.1"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,5 +28,9 @@
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4"
+  },
+  "engines": {
+    "node": ">=16.14.0 <18.0.0",
+    "npm": "^8.5.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,10 @@
         "textlint-rule-preset-ja-spacing": "^2.2.0",
         "textlint-rule-preset-ja-technical-writing": "^7.0.0",
         "textlint-rule-preset-jtf-style": "^2.3.12"
+      },
+      "engines": {
+        "node": ">=16.14.0 <18.0.0",
+        "npm": "^8.5.1"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
     "textlint-rule-preset-ja-spacing": "^2.2.0",
     "textlint-rule-preset-ja-technical-writing": "^7.0.0",
     "textlint-rule-preset-jtf-style": "^2.3.12"
+  },
+  "engines": {
+    "node": ">=16.14.0 <18.0.0",
+    "npm": "^8.5.1"
   }
 }

--- a/test/e2e/.npmrc
+++ b/test/e2e/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -11,6 +11,10 @@
       "devDependencies": {
         "cypress": "^9.0.0",
         "eslint-plugin-cypress": "^2.11.3"
+      },
+      "engines": {
+        "node": ">=16.14.0 <18.0.0",
+        "npm": "^8.5.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -11,5 +11,9 @@
   "devDependencies": {
     "cypress": "^9.0.0",
     "eslint-plugin-cypress": "^2.11.3"
+  },
+  "engines": {
+    "node": ">=16.14.0 <18.0.0",
+    "npm": "^8.5.1"
   }
 }


### PR DESCRIPTION
指定したバージョン以外で `npm install` できないようにします。
https://cumak.net/blog/engines/

dependabotのnodeのバージョンも考慮して、package.jsonでの指定は少し緩めにしてあります。
https://github.com/dependabot/dependabot-core/blob/31daef5ef4c96d83003777316e96a14eecddd190/Dockerfile#L100-L105