### PR TITLE
cypressのバージョンを明示的に指定する

### DIFF
--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^9.0.0",
+        "cypress": "^9.5.1",
         "eslint-plugin-cypress": "^2.11.3"
       },
       "engines": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^9.0.0",
+    "cypress": "^9.5.1",
     "eslint-plugin-cypress": "^2.11.3"
   },
   "engines": {


### PR DESCRIPTION
DependabotがアップデートのPRを出すときに `package.json` の差分がないのも (バージョン指定的に間違ってはいないのだが) なんとなく不自然に感じるので、 `package.json` で現状の `cypress` のバージョンを明示的に指定します。