### PR TITLE
pushトリガーの場合はdeploy-app-engineやdocker-compose-buildを無条件に実行する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
   deploy-app-engine:
     runs-on: ubuntu-latest
     needs: build-frontend
-    if: github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama'
+    if: github.event_name == 'push' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama')
     permissions:
       id-token: write
       contents: read
@@ -275,7 +275,7 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
     permissions:
       packages: write
-    if: github.repository == github.event.pull_request.head.repo.full_name
+    if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/runs/5457208950?check_suite_focus=true
forkしたリポジトリからのPRをマージした際にデプロイで落ちているので、pushトリガーの場合は `deploy-app-engine` や `docker-compose-build` を無条件に実行するようにします。