### PR TITLE
dev-hato/hato-atamaを環境変数として置く

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+env:
+  ORIGIN_REPOSITORY: dev-hato/hato-atama
+
 jobs:
   build-frontend:
     runs-on: ubuntu-latest
@@ -32,7 +35,7 @@ jobs:
   deploy-app-engine:
     runs-on: ubuntu-latest
     needs: build-frontend
-    if: github.event_name == 'push' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama')
+    if: github.event_name == 'push' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == env.ORIGIN_REPOSITORY)
     permissions:
       id-token: write
       contents: read
@@ -433,7 +436,7 @@ jobs:
       - run: exit 0
 
   # 以下がskipされていても完了したものと見なす
-  # * forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合: docker-compose-build, deploy-app-engine
+  # * forkしたリポジトリからORIGIN_REPOSITORYへPRを出した場合: docker-compose-build, deploy-app-engine
   # * forkしたリポジトリ上でPRを立てた場合: deploy-app-engine
   pr-test-complete:
     runs-on: ubuntu-latest
@@ -443,9 +446,9 @@ jobs:
       - docker-compose-build
       - pr-test-complete-check-deploy-app-engine
     steps:
-      - if: ${{ needs.e2e-test-all-docker-compose.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || (needs.docker-compose-build.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.pr-test-complete-check-deploy-app-engine.result == 'success'))) }}
+      - if: ${{ needs.e2e-test-all-docker-compose.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || (needs.docker-compose-build.result == 'success' && (github.repository != env.ORIGIN_REPOSITORY || needs.pr-test-complete-check-deploy-app-engine.result == 'success'))) }}
         run: exit 0
-      - if: ${{ needs.e2e-test-all-docker-compose.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && (needs.docker-compose-build.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.pr-test-complete-check-deploy-app-engine.result != 'success'))) }}
+      - if: ${{ needs.e2e-test-all-docker-compose.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && (needs.docker-compose-build.result != 'success' || (github.repository == env.ORIGIN_REPOSITORY && needs.pr-test-complete-check-deploy-app-engine.result != 'success'))) }}
         run: exit 1
 
   release-complete-check:


### PR DESCRIPTION
本リポジトリを別orgに移動させても変更箇所が少なくなるよう、CI `release` の `dev-hato/hato-atama` を環境変数としておきます。