### PR TITLE
golangのDockerイメージの除外対象追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: golang
         versions:
           - 1.18rc1-bullseye
+          - 1.18beta2-bullseye
     open-pull-requests-limit: 1
   - package-ecosystem: "elm"
     directory: "/frontend"


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/811 はbeta版なのでアップデート対象から除外します。