### PR TITLE
GCPの認証が必要なCIでcheckoutする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/checkout@v3
       - uses: google-github-actions/setup-gcloud@v0.6.0
         with:
           project_id: 'hato-atama'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,6 +334,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/checkout@v3
       - name: Get run numbers
         uses: actions/github-script@v6
         id: get_run_numbers

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -3,8 +3,6 @@ name: remove-app-engine-versions
 
 on:
   pull_request:
-    types:
-      - closed
 
 jobs:
   remove-app-engine-versions:
@@ -99,5 +97,5 @@ jobs:
           gcloud auth login --brief --cred-file="${FILE_PATH}"
       - if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: |
-          NUMBER="${{steps.get_run_numbers.outputs.result}}"
+          NUMBER="v1778"
           gcloud app versions delete --service=default "${NUMBER}"

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
     if: github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama'
     steps:
+      - uses: actions/checkout@v3
       - name: Get run numbers
         uses: actions/github-script@v6
         id: get_run_numbers

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -3,6 +3,8 @@ name: remove-app-engine-versions
 
 on:
   pull_request:
+    types:
+      - closed
 
 jobs:
   remove-app-engine-versions:
@@ -97,5 +99,5 @@ jobs:
           gcloud auth login --brief --cred-file="${FILE_PATH}"
       - if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: |
-          NUMBER="v1778"
+          NUMBER="${{steps.get_run_numbers.outputs.result}}"
           gcloud app versions delete --service=default "${NUMBER}"

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/go-playground/validator/v10 v10.10.1
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/labstack/echo/v4 v4.7.2
-	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 // indirect
+	golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -369,8 +369,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 h1:A9i04dxx7Cribqbs8jf3FQLogkL/CV2YN7hj9KWJCkc=
-golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf h1:Fm4IcnUL803i92qDlmB0obyHmosDrxZWxJL3gIeNqOw=
+golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
https://github.com/google-github-actions/auth#other-inputs
> `create_credentials_file`: (Optional) If true, the action will securely generate a credentials file which can be used for authentication via gcloud and Google Cloud SDKs in other steps in the workflow. The default is true.
> 
> The credentials file is exported into `$GITHUB_WORKSPACE`, which makes it available to all future steps and filesystems (including Docker-based GitHub Actions). The file is automatically removed at the end of the job via a post action. In order to use exported credentials, you **must** add the `actions/checkout` step before calling `auth`. This is due to how GitHub Actions creates `$GITHUB_WORKSPACE`:
> 
> ```yaml
> jobs:
>  job_id:
>    steps:
>    - uses: 'actions/checkout@v3' # Must come first!
>    - uses: 'google-github-actions/auth@v0'
> ```

`google-github-actions/auth` で `create_credentials_file: true` を付与する場合、 `actions/checkout` を行う必要があるようなので、 `actions/checkout` を追加します。