### PR TITLE
app engineのバージョン削除コマンド修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,8 +420,8 @@ jobs:
       - name: Remove app engine versions
         if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: |
-          NUMBER="${{steps.get_run_numbers.outputs.result}}"
-          gcloud app versions delete --service=default "${NUMBER}"
+          gcloud app versions delete --service=default \
+                                     ${{steps.get_run_numbers.outputs.result}}
 
   # deploy-app-engineに依存しているjobが完了したか
   pr-test-complete-check-deploy-app-engine:

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -99,5 +99,5 @@ jobs:
           gcloud auth login --brief --cred-file="${FILE_PATH}"
       - if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: |
-          NUMBER="${{steps.get_run_numbers.outputs.result}}"
-          gcloud app versions delete --service=default "${NUMBER}"
+          gcloud app versions delete --service=default \
+                                     ${{steps.get_run_numbers.outputs.result}}

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -3,8 +3,6 @@ name: remove-app-engine-versions
 
 on:
   pull_request:
-    types:
-      - closed
 
 jobs:
   remove-app-engine-versions:
@@ -100,4 +98,4 @@ jobs:
       - if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: |
           gcloud app versions delete --service=default \
-                                     ${{steps.get_run_numbers.outputs.result}}
+                                     v1783 v1782 v1781 v1780

--- a/.github/workflows/remove_app_engine_versions.yml
+++ b/.github/workflows/remove_app_engine_versions.yml
@@ -3,6 +3,8 @@ name: remove-app-engine-versions
 
 on:
   pull_request:
+    types:
+      - closed
 
 jobs:
   remove-app-engine-versions:
@@ -98,4 +100,4 @@ jobs:
       - if: ${{ steps.get_run_numbers.outputs.result != '' }}
         run: |
           gcloud app versions delete --service=default \
-                                     v1783 v1782 v1781 v1780
+                                     ${{steps.get_run_numbers.outputs.result}}


### PR DESCRIPTION
app engineのバージョン削除コマンドにおいて、バージョンを正しく認識させるため、バージョンをダブルクオートで囲まないようにします。