### PR TITLE
GCPの認証情報をenvにまとめる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+env:
+  GCP_WORKLOAD_IDENTITY_PROVIDER: 'projects/765091727073/locations/global/workloadIdentityPools/hato-atama-workload-identity/providers/github'
+  GCP_SERVICE_ACCOUNT: 'actions-deploy@hato-atama.iam.gserviceaccount.com'
+
 jobs:
   build-frontend:
     runs-on: ubuntu-latest
@@ -52,8 +56,8 @@ jobs:
         name: 'Authenticate to GCP'
         uses: google-github-actions/auth@v0.7.0
         with:
-          workload_identity_provider: 'projects/765091727073/locations/global/workloadIdentityPools/hato-atama-workload-identity/providers/github'
-          service_account: 'actions-deploy@hato-atama.iam.gserviceaccount.com'
+          workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          service_account: ${{env.GCP_SERVICE_ACCOUNT}}
       - uses: google-github-actions/setup-gcloud@v0.6.0
       - name: Deploy to App Engine
         uses: google-github-actions/deploy-appengine@v0.8.0
@@ -305,8 +309,8 @@ jobs:
         name: 'Authenticate to GCP'
         uses: google-github-actions/auth@v0.7.0
         with:
-          workload_identity_provider: 'projects/765091727073/locations/global/workloadIdentityPools/hato-atama-workload-identity/providers/github'
-          service_account: 'actions-deploy@hato-atama.iam.gserviceaccount.com'
+          workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          service_account: ${{env.GCP_SERVICE_ACCOUNT}}
       - uses: google-github-actions/setup-gcloud@v0.6.0
       - run: |
           VALUE="v${GITHUB_RUN_NUMBER}=1"
@@ -393,8 +397,8 @@ jobs:
         name: 'Authenticate to GCP'
         uses: google-github-actions/auth@v0.7.0
         with:
-          workload_identity_provider: 'projects/765091727073/locations/global/workloadIdentityPools/hato-atama-workload-identity/providers/github'
-          service_account: 'actions-deploy@hato-atama.iam.gserviceaccount.com'
+          workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          service_account: ${{env.GCP_SERVICE_ACCOUNT}}
       - uses: google-github-actions/setup-gcloud@v0.6.0
         if: ${{ steps.get_run_numbers.outputs.result != '' }}
       - name: Remove app engine versions


### PR DESCRIPTION
CI `release` においてGCPの認証情報が何回も登場しているので `env` にまとめます。