### PR TITLE
.jscpd.jsonをsuper-linterに寄せる

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,3 +1,11 @@
 {
+  "threshold": 0,
+  "reporters": [
+    "consoleFull"
+  ],
+  "ignore": [
+    "**/__snapshots__/**"
+  ],
+  "absolute": true,
   "min-lines": 15
 }


### PR DESCRIPTION
https://github.com/github/super-linter/blob/ab8780a58f056cc470449cf96a41982c742dcaf8/TEMPLATES/.jscpd.json

`.jscpd.json` を上記に寄せたら以下のWarningが解消されないかしら......。

https://github.com/dev-hato/hato-atama/actions/runs/2151613108

```
super-linter: .jscpd.json#L1
File ignored by default.
```