### PR TITLE
Dependabotとhato-atamaでNode.jsやnpmのバージョンが同じ場合は重複して記述しないようにする

### DIFF
--- a/.github/workflows/update_nodejs.yml
+++ b/.github/workflows/update_nodejs.yml
@@ -241,9 +241,25 @@ jobs:
           NPM_VERSION="${{steps.get_node_version.outputs.npm_version}}"
           for path in "frontend" "test/e2e" "."; do
             echo "${NODE_VERSION}" > ${path}/.node-version
-            NODE_PATTERN="s/\"node\": \".*\"/\"node\": \"^${DEPENDABOT_NODE_VERSION} || ^${NODE_VERSION}\"/g"
+
+            NODE_PATTERN="s/\"node\": \".*\"/\"node\": \"^${DEPENDABOT_NODE_VERSION}"
+
+            if [ "${DEPENDABOT_NODE_VERSION}" != "${NODE_VERSION}" ]
+            then
+              NODE_PATTERN+=" || ^${NODE_VERSION}"
+            fi
+
+            NODE_PATTERN+="\"/g"
             sed -i -e "${NODE_PATTERN}" ${path}/package.json
-            NPM_PATTERN="s/\"npm\": \".*\"/\"npm\": \"^${DEPENDABOT_NPM_VERSION} || ^${NPM_VERSION}\"/g"
+
+            NPM_PATTERN="s/\"npm\": \".*\"/\"npm\": \"^${DEPENDABOT_NPM_VERSION}"
+
+            if [ "${DEPENDABOT_NPM_VERSION}" != "${NPM_VERSION}" ]
+            then
+              NPM_PATTERN+=" || ^${NPM_VERSION}"
+            fi
+
+            NPM_PATTERN+="\"/g"
             sed -i -e "${NPM_PATTERN}" ${path}/package.json
           done
       # 差分があったときは差分を出力する


### PR DESCRIPTION
Dependabotとhato-atamaでNode.jsやnpmのバージョンが同じ場合は重複して記述しないようにします。