### PR TITLE
npm installの代わりにnpm ci --prefer-offlineを使う

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,7 @@ jobs:
           node-version-file: frontend/.node-version
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: npm install
-        run: npm install
+      - run: npm ci --prefer-offline
       - name: build
         run: npm run build
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: npm
-      - run: npm install
+      - run: npm ci --prefer-offline
       - name: Super-Linter
         uses: github/super-linter@v4.9.2
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.8.1
+    rev: v8.8.2
     hooks:
       - id: gitleaks


### PR DESCRIPTION
`npm install` の代わりに `npm ci --prefer-offline` を使うことでCIの実行時間を短縮してみます。
* `npm ci`: `package-lock.json` (≠ `package.json` ) を元にインストールする
* `--prefer-offline`: ローカルキャッシュがある場合はそれを使ってインストールする, そうでない場合はサーバーからダウンロードする