### PR TITLE
docker-compose-buildをreleaseから分離

### DIFF
--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -1,0 +1,43 @@
+---
+name: docker-compose-build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  docker-compose-build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+      COMPOSE_DOCKER_CLI_BUILD: 1
+    permissions:
+      packages: write
+    if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
+        env:
+          HEAD_REF: ${{github.head_ref}}
+        if: ${{ github.event_name == 'pull_request' }}
+      - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
+        if: ${{ github.event_name == 'push' }}
+      - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
+      - name: Build and push
+        uses: docker/bake-action@v1.7.0
+        with:
+          push: true
+          files: staging.docker-compose.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,40 +271,6 @@ jobs:
           npm run test -- --env "${ENV}" --browser ${{ matrix.browser }}
         working-directory: ./test/e2e
 
-  docker-compose-build:
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
-      COMPOSE_DOCKER_CLI_BUILD: 1
-    permissions:
-      packages: write
-    if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-      - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
-        env:
-          HEAD_REF: ${{github.head_ref}}
-        if: ${{ github.event_name == 'pull_request' }}
-      - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
-        if: ${{ github.event_name == 'push' }}
-      - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
-      - name: Build and push
-        uses: docker/bake-action@v1.7.0
-        with:
-          push: true
-          files: staging.docker-compose.yml
-
   migrating-traffic:
     runs-on: ubuntu-latest
     needs:
@@ -428,20 +394,17 @@ jobs:
     steps:
       - run: exit 0
 
-  # 以下がskipされていても完了したものと見なす
-  # * forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合: docker-compose-build, deploy-app-engine
-  # * forkしたリポジトリ上でPRを立てた場合: deploy-app-engine
+  # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合はdeploy-app-engineがskipされていても完了したものと見なす
   pr-test-complete:
     runs-on: ubuntu-latest
     if: ${{ always() && github.event_name == 'pull_request' }}
     needs:
       - e2e-test-all-docker-compose
-      - docker-compose-build
       - pr-test-complete-check-deploy-app-engine
     steps:
-      - if: ${{ needs.e2e-test-all-docker-compose.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || (needs.docker-compose-build.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.pr-test-complete-check-deploy-app-engine.result == 'success'))) }}
+      - if: ${{ needs.e2e-test-all-docker-compose.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.pr-test-complete-check-deploy-app-engine.result == 'success') }}
         run: exit 0
-      - if: ${{ needs.e2e-test-all-docker-compose.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && (needs.docker-compose-build.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.pr-test-complete-check-deploy-app-engine.result != 'success'))) }}
+      - if: ${{ needs.e2e-test-all-docker-compose.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.pr-test-complete-check-deploy-app-engine.result != 'success') }}
         run: exit 1
 
   release-complete-check:
@@ -449,7 +412,6 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     needs:
       - remove-app-engine-past-versions
-      - docker-compose-build
       - lighthouse
     steps:
       - run: exit 0


### PR DESCRIPTION
`docker-compose-build` は `release` の中で突出して実行時間がかかるため、これだけ分離して別のCIとします。