### PR TITLE
Dockerイメージビルド前にpullする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,8 @@ jobs:
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
+      - run: docker-compose -f staging.docker-compose.yml pull
+        continue-on-error: true
       - run: docker-compose -f staging.docker-compose.yml build
       - run: docker-compose -f staging.docker-compose.yml up -d
       - uses: actions/setup-node@v3.1.1
@@ -208,6 +210,8 @@ jobs:
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
+      - run: docker-compose -f staging.docker-compose.yml pull
+        continue-on-error: true
       - run: docker-compose -f staging.docker-compose.yml build
       - run: docker-compose -f staging.docker-compose.yml up -d
       - uses: actions/setup-node@v3.1.1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001336",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
       "dev": true,
       "funding": [
         {
@@ -4997,9 +4997,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001336",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
       "dev": true
     },
     "chokidar": {


### PR DESCRIPTION
Dockerイメージビルド前にpullするとキャッシュが効きそうなので、pullするようにしてみます。
最初のCI実行時にはpullする対象がないはずなので、失敗しても処理を続行するようにしています。