### PR TITLE
stagingとdevでサービス名が重複しないようにする

### DIFF
--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -63,7 +63,7 @@ jobs:
         id: get_go_version
         run: |
           CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
-          go_version=$(docker compose -f dev.docker-compose.yml run server sh -c "${CMD}")
+          go_version=$(docker compose -f dev.docker-compose.yml run server-dev sh -c "${CMD}")
           echo "Go version:" "${go_version}"
           echo "::set-output name=go_version::${go_version}"
       - name: Set up Go
@@ -446,7 +446,7 @@ jobs:
         id: get_node_version
         run: |
           DOCKER_CMD="node --version && npm --version"
-          mapfile -t result < <(docker compose -f dev.docker-compose.yml run frontend sh -c "${DOCKER_CMD}")
+          mapfile -t result < <(docker compose -f dev.docker-compose.yml run frontend-dev sh -c "${DOCKER_CMD}")
           node_version="${result[0]//v/}"
           npm_version=${result[1]}
           echo "Node.js version:" "${node_version}"

--- a/.github/workflows/resource-update.yml
+++ b/.github/workflows/resource-update.yml
@@ -108,7 +108,7 @@ jobs:
         id: get_go_version
         run: |
           DOCKER_CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
-          go_version=$(docker compose -f dev.docker-compose.yml run server sh -c "${DOCKER_CMD}")
+          go_version=$(docker compose -f dev.docker-compose.yml run server-dev sh -c "${DOCKER_CMD}")
           echo "Go version:" "${go_version}"
           echo "::set-output name=go_version::${go_version}"
       - name: Set up Go

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -19,7 +19,7 @@ services:
       DATASTORE_PROJECT_ID: app
       DATASTORE_LISTEN_ADDRESS: 0.0.0.0:8081
 
-  server:
+  server-dev:
     build:
       context: .
       dockerfile: server/Dockerfile
@@ -42,7 +42,7 @@ services:
     ports:
       - "8082:8082"
 
-  frontend:
+  frontend-dev:
     build:
       context: .
       dockerfile: frontend/Dockerfile


### PR DESCRIPTION
stagingとdevでサービス名が重複していると、Dockerイメージのビルド時にstagingとdevの設定が混線するようなので (以下参照)、重複しないようにdevのサービス名を変更します。

https://github.com/dev-hato/hato-atama/runs/6332817829?check_suite_focus=true

<details>

```
Bake definition
  /usr/bin/docker buildx bake --file dev.docker-compose.yml --file staging.docker-compose.yml --metadata-file /tmp/docker-build-push-eeyBjT/metadata-file --pull --push --print
  {
    "group": {
      "default": {
        "targets": [
          "server",
          "frontend",
          "gcloud_datastore"
        ]
      }
    },
    "target": {
      "frontend": {
        "context": ".",
        "dockerfile": "frontend/Dockerfile",
        "tags": [
          "ghcr.io/dev-hato/hato-atama/frontend:latest"
        ],
        "cache-from": [
          "ghcr.io/dev-hato/hato-atama/frontend-dev:latest",
          "ghcr.io/dev-hato/hato-atama/frontend-dev",
          "ghcr.io/dev-hato/hato-atama/frontend:latest",
          "ghcr.io/dev-hato/hato-atama/frontend"
        ],
        "target": "build",
        "platforms": [
          "linux/amd64",
          "linux/arm64"
        ],
        "output": [
          "type=image,push=true"
        ],
        "pull": true
      },
      "gcloud_datastore": {
        "context": ".",
        "dockerfile": "gcp/datastore/Dockerfile",
        "tags": [
          "ghcr.io/dev-hato/hato-atama/gcloud_datastore:latest"
        ],
        "cache-from": [
          "ghcr.io/dev-hato/hato-atama/gcloud_datastore:latest",
          "ghcr.io/dev-hato/hato-atama/gcloud_datastore"
        ],
        "platforms": [
          "linux/amd64",
          "linux/arm64"
        ],
        "output": [
          "type=image,push=true"
        ],
        "pull": true
      },
      "server": {
        "context": ".",
        "dockerfile": "server/Dockerfile",
        "tags": [
          "ghcr.io/dev-hato/hato-atama/server:latest"
        ],
        "cache-from": [
          "ghcr.io/dev-hato/hato-atama/server-dev:latest",
          "ghcr.io/dev-hato/hato-atama/server-dev",
          "ghcr.io/dev-hato/hato-atama/server:latest",
          "ghcr.io/dev-hato/hato-atama/server"
        ],
        "target": "build",
        "platforms": [
          "linux/amd64",
          "linux/arm64"
        ],
        "output": [
          "type=image,push=true"
        ],
        "pull": true
      }
    }
  }
```

</details>