### PR TITLE
gcloud_datastoreコンテナにinit processを仕込む

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -14,6 +14,7 @@ services:
           - linux/amd64
           - linux/arm64
     image: ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+    init: true
     tty: true
     environment:
       DATASTORE_PROJECT_ID: app

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -15,6 +15,7 @@ services:
           - linux/amd64
           - linux/arm64
     image: ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+    init: true
     tty: true
     environment:
       DATASTORE_PROJECT_ID: app


### PR DESCRIPTION
https://christina04.hatenablog.com/entry/docker-init

コンテナ終了時の挙動を見る限り、 `gcloud_datastore` はシグナルハンドリングできていなさそうなので、init processを仕込みます。