### PR TITLE
Dockerfile内でnpm ciを使う

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get remove -y curl \
 
 COPY frontend/.npmrc .
 COPY frontend/package*.json ./
-RUN npm install
+RUN npm ci
 
 COPY frontend/webpack.config.js ./
 COPY frontend/src ./src


### PR DESCRIPTION
Dockerfile内で `npm install` の代わりに `npm ci` を使うことで、開発環境とのパッケージの差を無くします。