### PR TITLE
DockleのCIでのpush時のタグ設定修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -800,6 +800,9 @@ jobs:
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
           HEAD_REF: ${{github.head_ref}}
+        if: ${{ github.event_name == 'pull_request' }}
+      - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
+        if: ${{ github.event_name == 'push' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - run: |
           VERSION=$(


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/runs/6537745896?check_suite_focus=true

```
WARNING: Some service image(s) must be built from source by running:
    docker compose build %s frontend server gcloud_datastore
invalid reference format
```

masterへのpush時には `latest` のイメージを取得するのが正しいですが、その辺りの処理が抜けていたので追加します。