### PR TITLE
Dockerイメージのビルド時間改善

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,6 @@ jobs:
           DOCKER_CONTENT_TRUST: 1
         with:
           push: true
-          pull: true
           files: dev.docker-compose.yml
       - name: Build and push (staging)
         uses: docker/bake-action@v2.0.0
@@ -190,7 +189,6 @@ jobs:
           DOCKER_CONTENT_TRUST: 1
         with:
           push: true
-          pull: true
           files: staging.docker-compose.yml
 
   format-go:
@@ -803,12 +801,6 @@ jobs:
       DOCKER_CONTENT_TRUST: 1
     steps:
       - uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
           HEAD_REF: ${{github.head_ref}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,16 +176,22 @@ jobs:
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'push' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
-      - name: Build and push
+      - name: Build and push (dev)
         uses: docker/bake-action@v2.0.0
         env:
           DOCKER_CONTENT_TRUST: 1
         with:
           push: true
           pull: true
-          files: |
-            dev.docker-compose.yml
-            staging.docker-compose.yml
+          files: dev.docker-compose.yml
+      - name: Build and push (staging)
+        uses: docker/bake-action@v2.0.0
+        env:
+          DOCKER_CONTENT_TRUST: 1
+        with:
+          push: true
+          pull: true
+          files: staging.docker-compose.yml
 
   format-go:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -803,6 +803,12 @@ jobs:
       DOCKER_CONTENT_TRUST: 1
     steps:
       - uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
           HEAD_REF: ${{github.head_ref}}

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -14,8 +14,8 @@ services:
       x-bake:
         cache-from:
           - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
           - type=gha,mode=max
         platforms:
@@ -41,8 +41,8 @@ services:
       x-bake:
         cache-from:
           - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
         cache-to:
           - type=gha,mode=max
         platforms:
@@ -72,8 +72,8 @@ services:
       x-bake:
         cache-from:
           - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
         cache-to:
           - type=gha,mode=max
         platforms:

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -9,6 +9,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         cache-from:
           - type=gha
@@ -16,8 +18,6 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
           - type=gha,mode=max
-        args:
-          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -36,6 +36,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         cache-from:
           - type=gha
@@ -43,8 +45,6 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
         cache-to:
           - type=gha,mode=max
-        args:
-          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -67,6 +67,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         cache-from:
           - type=gha
@@ -74,8 +76,6 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
         cache-to:
           - type=gha,mode=max
-        args:
-          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -12,12 +12,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -39,12 +33,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -70,12 +58,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -10,6 +10,12 @@ services:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+        cache-to:
+          - type=gha
         platforms:
           - linux/amd64
           - linux/arm64
@@ -29,6 +35,12 @@ services:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
+        cache-to:
+          - type=gha
         platforms:
           - linux/amd64
           - linux/arm64
@@ -52,6 +64,12 @@ services:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
+        cache-to:
+          - type=gha
         platforms:
           - linux/amd64
           - linux/arm64

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -16,6 +16,8 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
           - type=gha,mode=max
+        args:
+          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -41,6 +43,8 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
         cache-to:
           - type=gha,mode=max
+        args:
+          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -70,6 +74,8 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
         cache-to:
           - type=gha,mode=max
+        args:
+          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -12,12 +12,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -39,12 +33,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -70,12 +58,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -15,7 +15,7 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
-          - type=gha
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -40,7 +40,7 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
         cache-to:
-          - type=gha
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -69,7 +69,7 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
         cache-to:
-          - type=gha
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -12,6 +12,12 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+        cache-to:
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -33,6 +39,12 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
+        cache-to:
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -58,6 +70,12 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
+        cache-to:
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -15,8 +15,8 @@ services:
       x-bake:
         cache-from:
           - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
           - type=gha,mode=max
         platforms:
@@ -41,8 +41,8 @@ services:
       x-bake:
         cache-from:
           - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
         cache-to:
           - type=gha,mode=max
         platforms:
@@ -68,8 +68,8 @@ services:
       x-bake:
         cache-from:
           - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
+          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
         cache-to:
           - type=gha,mode=max
         platforms:

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -11,6 +11,12 @@ services:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+        cache-to:
+          - type=gha
         platforms:
           - linux/amd64
           - linux/arm64
@@ -29,6 +35,12 @@ services:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
+        cache-to:
+          - type=gha
         platforms:
           - linux/amd64
           - linux/arm64
@@ -48,6 +60,12 @@ services:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
+        cache-to:
+          - type=gha
         platforms:
           - linux/amd64
           - linux/arm64

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -13,12 +13,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -39,12 +33,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -66,12 +54,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
-          - type=registry,ref=ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -17,6 +17,8 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
           - type=gha,mode=max
+        args:
+          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -41,6 +43,8 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
         cache-to:
           - type=gha,mode=max
+        args:
+          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -66,6 +70,8 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
         cache-to:
           - type=gha,mode=max
+        args:
+          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -30,6 +30,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server-dev
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
@@ -51,6 +53,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend-dev
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -13,6 +13,12 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+        cache-to:
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -33,6 +39,12 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
+        cache-to:
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -54,6 +66,12 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
+        cache-from:
+          - type=gha
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
+          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
+        cache-to:
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -13,12 +13,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -39,12 +33,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -66,12 +54,6 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
-        cache-from:
-          - type=gha
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
-          - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
-        cache-to:
-          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -16,7 +16,7 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
-          - type=gha
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -40,7 +40,7 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
         cache-to:
-          - type=gha
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64
@@ -65,7 +65,7 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
         cache-to:
-          - type=gha
+          - type=gha,mode=max
         platforms:
           - linux/amd64
           - linux/arm64

--- a/staging.docker-compose.yml
+++ b/staging.docker-compose.yml
@@ -10,6 +10,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         cache-from:
           - type=gha
@@ -17,8 +19,6 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/gcloud_datastore
         cache-to:
           - type=gha,mode=max
-        args:
-          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -36,6 +36,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         cache-from:
           - type=gha
@@ -43,8 +45,6 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/server
         cache-to:
           - type=gha,mode=max
-        args:
-          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64
@@ -63,6 +63,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         cache-from:
           - type=gha
@@ -70,8 +72,6 @@ services:
           - ghcr.io/${REPOSITORY:-dev-hato/hato-atama}/frontend
         cache-to:
           - type=gha,mode=max
-        args:
-          - BUILDKIT_INLINE_CACHE=1
         platforms:
           - linux/amd64
           - linux/arm64


### PR DESCRIPTION
Dockerイメージのビルドに時間がかかりすぎているので修正します。
* staging用のイメージのビルド時に開発環境用のイメージをキャッシュとして使うようにする
* 常に最新のイメージをpullすると時間がかかりそうなので `pull: true` 削除
* `BUILDKIT_INLINE_CACHE=1` 設定