### PR TITLE
リダイレクト時のステータスコードを定数で与える

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -240,7 +240,7 @@ func getLink(c echo.Context) (err error) {
 
 	c.Response().Header().Set("Cache-Control", "no-store")
 	// トランザクションがコミットされれば、URLにリダイレクトさせる
-	return c.Redirect(302, data.URLData)
+	return c.Redirect(http.StatusFound, data.URLData)
 }
 
 func initialize() (err error) {


### PR DESCRIPTION
リダイレクト時のステータスコードが整数で与えられていますが、定数で与えるようにします。