### PR TITLE
test/e2e以下もrenovateの対象にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,20 @@
     "config:base",
     ":timezone(Asia/Tokyo)"
   ],
+  "includePaths": [
+    "elm/Dockerfile",
+    "frontend/Dockerfile",
+    "gcp/datastore/Dockerfile",
+    "server/Dockerfile",
+    ".github/workflows/*.yml",
+    "go.mod",
+    ".node-version",
+    "frontend/.node-version",
+    "test/e2e/.node-version",
+    "frontend/package.json",
+    "test/e2e/package.json",
+    "package.json"
+  ],
   "automerge": true,
   "platformAutomerge": true
 }


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/issues/1004 を見る限り、 `test/e2e` 以下はrenovateの対象になってなさそうなので、明示的に対象にします。