### PR TITLE
push時のCIでのTAG_NAME修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,9 @@ jobs:
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
           HEAD_REF: ${{github.head_ref}}
+        if: github.event_name == 'pull_request'
+      - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
+        if: github.event_name == 'push'
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - run: docker compose -f dev.docker-compose.yml pull
       - name: Get Go version
@@ -304,6 +307,9 @@ jobs:
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
           HEAD_REF: ${{github.head_ref}}
+        if: github.event_name == 'pull_request'
+      - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
+        if: github.event_name == 'push'
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - run: docker compose -f dev.docker-compose.yml pull
         env:


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/runs/7135869148?check_suite_focus=true

```
Run docker compose -f dev.docker-compose.yml pull
  docker compose -f dev.docker-compose.yml pull
  shell: /usr/bin/bash -e {0}
  env:
    ...
    TAG_NAME: 
    REPOSITORY: dev-hato/hato-atama
Error response from daemon: no such image: ghcr.io/dev-hato/hato-atama/frontend-dev:: invalid reference format
```

`TAG_NAME` が空になって失敗しているので、push時は `latest` を指定するようにします。