### PR TITLE
WorkflowレベルのconcurrencyでCI releaseの排他制御を行う

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: 'projects/765091727073/locations/global/workloadIdentityPools/hato-atama-workload-identity/providers/github'
   GCP_SERVICE_ACCOUNT: 'actions-deploy@hato-atama.iam.gserviceaccount.com'
 
+concurrency: release
+
 jobs:
   build-frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI `release` が並列で実行されないようにすることで、本番環境へのアクセス数を減らします。