### PR TITLE
本番環境に同時にアクセスするCIを1つだけにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: 'projects/765091727073/locations/global/workloadIdentityPools/hato-atama-workload-identity/providers/github'
   GCP_SERVICE_ACCOUNT: 'actions-deploy@hato-atama.iam.gserviceaccount.com'
 
-concurrency: release
-
 jobs:
   build-frontend:
     runs-on: ubuntu-latest
@@ -126,6 +124,7 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     needs: deploy-app-engine
+    concurrency: production_access
     permissions:
       pull-requests: write
     steps:
@@ -506,12 +505,11 @@ jobs:
 
   e2e-test-mini-prd:
     runs-on: ubuntu-latest
+    concurrency: production_access
     needs:
       - deploy-app-engine
       - e2e-test-mini-docker-compose
-    strategy:
-      matrix:
-        browser: ["chrome", "chromium", "firefox", "electron"]
+      - lighthouse
     env:
       DOCKER_CONTENT_TRUST: 1
     steps:
@@ -524,21 +522,21 @@ jobs:
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
       - run: |
-          API_HOST="https://"
-          API_HOST+="v${GITHUB_RUN_NUMBER}-dot-hato-atama.an.r.appspot.com"
-          npm run test -- --env "API_HOST=${API_HOST}" \
-                          --spec cypress/e2e/mini/*.cy.js \
-                          --browser ${{ matrix.browser }}
+          for browser in chrome chromium firefox electron; do
+            API_HOST="https://"
+            API_HOST+="v${GITHUB_RUN_NUMBER}-dot-hato-atama.an.r.appspot.com"
+            npm run test -- --env "API_HOST=${API_HOST}" \
+                            --spec cypress/e2e/mini/*.cy.js \
+                            --browser "${browser}"
+          done
         working-directory: ./test/e2e
 
   e2e-test-all-prd:
     runs-on: ubuntu-latest
+    concurrency: production_access
     needs:
       - e2e-test-all-docker-compose
       - e2e-test-mini-prd
-    strategy:
-      matrix:
-        browser: ["chrome", "chromium", "firefox", "electron"]
     if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v3.0.2
@@ -550,9 +548,11 @@ jobs:
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
       - run: |
-          ENV="API_HOST="
-          ENV+="https://v${GITHUB_RUN_NUMBER}-dot-hato-atama.an.r.appspot.com"
-          npm run test -- --env "${ENV}" --browser ${{ matrix.browser }}
+          for browser in chrome chromium firefox electron; do
+            ENV="API_HOST="
+            ENV+="https://v${GITHUB_RUN_NUMBER}-dot-hato-atama.an.r.appspot.com"
+            npm run test -- --env "${ENV}" --browser "${browser}"
+          done
         working-directory: ./test/e2e
 
   migrating-traffic:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001361",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
-      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
+      "version": "1.0.30001362",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001362.tgz",
+      "integrity": "sha512-PFykHuC7BQTzCGQFaV6wD8IDRM3HpI83BXr99nNJhoOyDufgSuKlt0QVlWYt5ZJtEYFeuNVF5QY3kJcu8hVFjQ==",
       "dev": true,
       "funding": [
         {
@@ -5076,9 +5076,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001361",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
-      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
+      "version": "1.0.30001362",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001362.tgz",
+      "integrity": "sha512-PFykHuC7BQTzCGQFaV6wD8IDRM3HpI83BXr99nNJhoOyDufgSuKlt0QVlWYt5ZJtEYFeuNVF5QY3kJcu8hVFjQ==",
       "dev": true
     },
     "chokidar": {


### PR DESCRIPTION
以下のようにして同時に本番環境にアクセスするCIを1つだけにします。

* `lighthouse` <- `e2e-test-mini-prd` の依存を張ることでjobを直列化
* `lighthouse`, `e2e-test-mini-prd`, `e2e-test-all-prd` にconcurrency設定
* matrixを使っているとconcurrencyが不安定になる (2つ同時に実行されることがある) ので `e2e-test-mini-prd` や `e2e-test-all-prd` のmatrix部分をfor文に置き換える