### PR TITLE
--openssl-legacy-provider削除

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_OPTIONS=--openssl-legacy-provider cypress run -q"
+    "test": "cypress run -q"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
`NODE_OPTIONS=--openssl-legacy-provider` をつけなくてもE2Eテストが動くようになっていたので削除します。