### PR TITLE
e2e-test-mini-prdのタイムアウト延長

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,7 +495,7 @@ jobs:
   e2e-test-mini-prd:
     runs-on: ubuntu-latest
     concurrency: production_access
-    timeout-minutes: 2
+    timeout-minutes: 3
     needs:
       - deploy-app-engine
       - e2e-test-mini-docker-compose


### PR DESCRIPTION
`e2e-test-mini-prd` がタイムアウトでちょくちょく失敗しているので、タイムアウトを3分に延長します。