### PR TITLE
App Engineへのデプロイの有無を制御するCIにcheckoutのstep追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       deploy-files: ${{ steps.changes.outputs.deploy-files }}
     steps:
+      - uses: actions/checkout@v3.0.2
       - uses: dorny/paths-filter@v2.10.2
         id: changes
         with:


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/runs/7359347465?check_suite_focus=true

```
fatal: not a git repository (or any of the parent directories): .git
```

checkoutしていないのが原因で落ちていそうなのでcheckoutの処理を追加します。