### PR TITLE
App Engineにデプロイしない際にrelease-complete-checkが成功するようにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -714,7 +714,7 @@ jobs:
 
   release-complete-check:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && (needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.remove-app-engine-past-versions.result == 'success')) }}
+    if: ${{ github.event_name == 'push' }}
     needs:
       - remove-app-engine-past-versions
       - lighthouse
@@ -723,7 +723,10 @@ jobs:
       - format-go
       - dockle
     steps:
-      - run: exit 0
+      - if: needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.remove-app-engine-past-versions.result == 'success')
+        run: exit 0
+      - if: needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.remove-app-engine-past-versions.result != 'success')
+        run: exit 1
 
   release-complete:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/2677835528

App Engineにデプロイしない場合、 `release-complete-check` がスキップされて `release-complete` 失敗するので、このような場合でも `release-complete-check` を実行するようにします。