### PR TITLE
complete-check再編

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -684,17 +684,6 @@ jobs:
           gcloud app versions delete --service=default \
                                      ${{steps.get_run_numbers.outputs.result}}
 
-  # deploy-app-engineに依存しているjobが完了したか
-  pr-test-complete-check-deploy-app-engine:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-    needs:
-      - create-pr-environment
-      - e2e-test-mini-prd
-      - lighthouse
-    steps:
-      - run: exit 0
-
   # docker-compose-buildに依存しているjobが完了したか
   docker-compose-build-complete-check:
     runs-on: ubuntu-latest
@@ -702,34 +691,48 @@ jobs:
       - update-package
       - format-go
       - dockle
+      - e2e-test-all-docker-compose
     steps:
       - run: exit 0
+
+  # PRとpushで共通して完了しているべきjobが完了したか
+  release-complete-check:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - docker-compose-build-complete-check
+      - lighthouse
+      - e2e-test-mini-prd
+      - check-deploy-diff
+    steps:
+      - if: ${{ needs.docker-compose-build-complete-check.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success')) }}
+        run: exit 0
+      - if: ${{ needs.docker-compose-build-complete-check.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success')) }}
+        run: exit 1
 
   # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合はdeploy-app-engineがskipされていても完了したものと見なす
   pr-test-complete:
     runs-on: ubuntu-latest
     if: ${{ always() && github.event_name == 'pull_request' }}
     needs:
-      - e2e-test-all-docker-compose
-      - pr-test-complete-check-deploy-app-engine
+      - release-complete-check
+      - create-pr-environment
       - check-deploy-diff
-      - docker-compose-build-complete-check
     steps:
-      - if: ${{ needs.e2e-test-all-docker-compose.result == 'success' && needs.docker-compose-build-complete-check.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.pr-test-complete-check-deploy-app-engine.result == 'success') }}
+      - if: ${{ needs.release-complete-check.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.create-pr-environment.result == 'success') }}
         run: exit 0
-      - if: ${{ needs.e2e-test-all-docker-compose.result != 'success' || needs.docker-compose-build-complete-check.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.pr-test-complete-check-deploy-app-engine.result != 'success') }}
+      - if: ${{ needs.release-complete-check.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.create-pr-environment.result != 'success') }}
         run: exit 1
 
   release-complete:
     runs-on: ubuntu-latest
     if: ${{ always() && github.event_name == 'push' }}
     needs:
-      - docker-compose-build-complete-check
+      - release-complete-check
       - remove-app-engine-past-versions
-      - lighthouse
       - check-deploy-diff
     steps:
-      - if: ${{ needs.docker-compose-build-complete-check.result == 'success' && (needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.remove-app-engine-past-versions.result == 'success')) }}
+      - if: ${{ needs.release-complete-check.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.remove-app-engine-past-versions.result == 'success') }}
         run: exit 0
-      - if: ${{ needs.docker-compose-build-complete-check.result != 'success' || (needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.remove-app-engine-past-versions.result != 'success')) }}
+      - if: ${{ needs.release-complete-check.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.remove-app-engine-past-versions.result != 'success') }}
         run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -695,6 +695,16 @@ jobs:
     steps:
       - run: exit 0
 
+  # docker-compose-buildに依存しているjobが完了したか
+  docker-compose-build-complete-check:
+    runs-on: ubuntu-latest
+    needs:
+      - update-package
+      - format-go
+      - dockle
+    steps:
+      - run: exit 0
+
   # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合はdeploy-app-engineがskipされていても完了したものと見なす
   pr-test-complete:
     runs-on: ubuntu-latest
@@ -703,35 +713,23 @@ jobs:
       - e2e-test-all-docker-compose
       - pr-test-complete-check-deploy-app-engine
       - check-deploy-diff
-      - update-package
-      - format-go
-      - dockle
+      - docker-compose-build-complete-check
     steps:
-      - if: ${{ needs.e2e-test-all-docker-compose.result == 'success' && needs.update-package.result == 'success' && needs.format-go.result == 'success' && needs.dockle.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.pr-test-complete-check-deploy-app-engine.result == 'success') }}
+      - if: ${{ needs.e2e-test-all-docker-compose.result == 'success' && needs.docker-compose-build-complete-check.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.pr-test-complete-check-deploy-app-engine.result == 'success') }}
         run: exit 0
-      - if: ${{ needs.e2e-test-all-docker-compose.result != 'success' || needs.update-package.result != 'success' || needs.format-go.result != 'success' || needs.dockle.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.pr-test-complete-check-deploy-app-engine.result != 'success') }}
+      - if: ${{ needs.e2e-test-all-docker-compose.result != 'success' || needs.docker-compose-build-complete-check.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.pr-test-complete-check-deploy-app-engine.result != 'success') }}
         run: exit 1
-
-  release-complete-check:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
-    needs:
-      - update-package
-      - format-go
-      - dockle
-    steps:
-      - run: exit 0
 
   release-complete:
     runs-on: ubuntu-latest
     if: ${{ always() && github.event_name == 'push' }}
     needs:
-      - release-complete-check
+      - docker-compose-build-complete-check
       - remove-app-engine-past-versions
       - lighthouse
       - check-deploy-diff
     steps:
-      - if: ${{ needs.release-complete-check.result == 'success' && (needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.remove-app-engine-past-versions.result == 'success')) }}
+      - if: ${{ needs.docker-compose-build-complete-check.result == 'success' && (needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.remove-app-engine-past-versions.result == 'success')) }}
         run: exit 0
-      - if: ${{ needs.release-complete-check.result != 'success' || (needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.remove-app-engine-past-versions.result != 'success')) }}
+      - if: ${{ needs.docker-compose-build-complete-check.result != 'success' || (needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.remove-app-engine-past-versions.result != 'success')) }}
         run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -684,31 +684,31 @@ jobs:
           gcloud app versions delete --service=default \
                                      ${{steps.get_run_numbers.outputs.result}}
 
-  # docker-compose-buildに依存しているjobが完了したか
-  docker-compose-build-complete-check:
+  # deploy-app-engineに依存しているjobが完了したか
+  deploy-app-engine-complete-check:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - lighthouse
+      - e2e-test-mini-prd
+      - check-deploy-diff
+    steps:
+      - if: github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success')
+        run: exit 0
+      - if: github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success')
+        run: exit 1
+
+  # PRとpushで共通して完了しているべきjobが完了したか
+  release-complete-check:
     runs-on: ubuntu-latest
     needs:
+      - deploy-app-engine-complete-check
       - update-package
       - format-go
       - dockle
       - e2e-test-all-docker-compose
     steps:
       - run: exit 0
-
-  # PRとpushで共通して完了しているべきjobが完了したか
-  release-complete-check:
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - docker-compose-build-complete-check
-      - lighthouse
-      - e2e-test-mini-prd
-      - check-deploy-diff
-    steps:
-      - if: needs.docker-compose-build-complete-check.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success'))
-        run: exit 0
-      - if: needs.docker-compose-build-complete-check.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success'))
-        run: exit 1
 
   # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合はdeploy-app-engineがskipされていても完了したものと見なす
   pr-test-complete:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -716,25 +716,22 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
     needs:
-      - remove-app-engine-past-versions
-      - lighthouse
-      - check-deploy-diff
       - update-package
       - format-go
       - dockle
     steps:
-      - if: needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.remove-app-engine-past-versions.result == 'success')
-        run: exit 0
-      - if: needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.remove-app-engine-past-versions.result != 'success')
-        run: exit 1
+      - run: exit 0
 
   release-complete:
     runs-on: ubuntu-latest
     if: ${{ always() && github.event_name == 'push' }}
     needs:
       - release-complete-check
+      - remove-app-engine-past-versions
+      - lighthouse
+      - check-deploy-diff
     steps:
-      - if: ${{ needs.release-complete-check.result == 'success' }}
+      - if: ${{ needs.release-complete-check.result == 'success' && (needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.remove-app-engine-past-versions.result == 'success')) }}
         run: exit 0
-      - if: ${{ needs.release-complete-check.result != 'success' }}
+      - if: ${{ needs.release-complete-check.result != 'success' || (needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.remove-app-engine-past-versions.result != 'success')) }}
         run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,7 +726,7 @@ jobs:
 
   release-complete:
     runs-on: ubuntu-latest
-    if: always() && github.event_name == 'push'
+    if: ${{ always() && github.event_name == 'push' }}
     needs:
       - release-complete-check
       - remove-app-engine-past-versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -705,34 +705,34 @@ jobs:
       - e2e-test-mini-prd
       - check-deploy-diff
     steps:
-      - if: ${{ needs.docker-compose-build-complete-check.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success')) }}
+      - if: needs.docker-compose-build-complete-check.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success'))
         run: exit 0
-      - if: ${{ needs.docker-compose-build-complete-check.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success')) }}
+      - if: needs.docker-compose-build-complete-check.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success'))
         run: exit 1
 
   # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合はdeploy-app-engineがskipされていても完了したものと見なす
   pr-test-complete:
     runs-on: ubuntu-latest
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    if: always() && github.event_name == 'pull_request'
     needs:
       - release-complete-check
       - create-pr-environment
       - check-deploy-diff
     steps:
-      - if: ${{ needs.release-complete-check.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.create-pr-environment.result == 'success') }}
+      - if: needs.release-complete-check.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.create-pr-environment.result == 'success')
         run: exit 0
-      - if: ${{ needs.release-complete-check.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.create-pr-environment.result != 'success') }}
+      - if: needs.release-complete-check.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.create-pr-environment.result != 'success')
         run: exit 1
 
   release-complete:
     runs-on: ubuntu-latest
-    if: ${{ always() && github.event_name == 'push' }}
+    if: always() && github.event_name == 'push'
     needs:
       - release-complete-check
       - remove-app-engine-past-versions
       - check-deploy-diff
     steps:
-      - if: ${{ needs.release-complete-check.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.remove-app-engine-past-versions.result == 'success') }}
+      - if: needs.release-complete-check.result == 'success' && (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.remove-app-engine-past-versions.result == 'success')
         run: exit 0
-      - if: ${{ needs.release-complete-check.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.remove-app-engine-past-versions.result != 'success') }}
+      - if: needs.release-complete-check.result != 'success' || (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.remove-app-engine-past-versions.result != 'success')
         run: exit 1


### PR DESCRIPTION
`complate-check` 系のjobを以下のように再編します。

* `deploy-app-engine-complete-check`: (App Engineにデプロイした場合のみ) `deploy-app-engine` に依存しているjobが完了したか
* `release-complete-check`: PRとpushで共通して完了しているべきjobが完了したか
* `pr-test-complete`: PRをトリガーとした場合に完了しているべきjobが完了したか
* `release-complete`: pushをトリガーとした場合に完了しているべきjobが完了したか