### PR TITLE
setup-goのバージョンをgo.mod準拠にする

### DIFF
--- a/.github/workflows/format-go.yml
+++ b/.github/workflows/format-go.yml
@@ -1,0 +1,41 @@
+---
+name: release
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: sudo chown -R 1000:1000 server/
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Install goimports
+        run: |
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+          go install golang.org/x/tools/cmd/goimports@latest
+      - name: Format files
+        run: |
+          go_version=$(grep runtime app.yaml | sed -e 's/runtime: go\([0-9]\)\([0-9]*\)/\1.\2/g')
+          go mod tidy -go="${go_version}"
+          goimports -l -w .
+      - uses: dev-hato/actions-diff-pr-management@v0.0.10
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          branch-name-prefix: fix-format
+          pr-title-prefix: formatが間違ってたので直してあげたよ！
+          repo-name: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/format-go.yml
+++ b/.github/workflows/format-go.yml
@@ -1,5 +1,5 @@
 ---
-name: release
+name: format-go
 
 on:
   push:

--- a/.github/workflows/format-go.yml
+++ b/.github/workflows/format-go.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Format files
         run: |
           go_version=$(grep runtime app.yaml | sed -e 's/runtime: go\([0-9]\)\([0-9]*\)/\1.\2/g')
+          echo "${go_version}"
           go mod tidy -go="${go_version}"
           goimports -l -w .
       - uses: dev-hato/actions-diff-pr-management@v0.0.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,54 +212,6 @@ jobs:
           push: true
           files: docker-compose.yml,staging.docker-compose.yml
 
-  format-go:
-    runs-on: ubuntu-latest
-    needs: docker-compose-build
-    permissions:
-      contents: write
-      pull-requests: write
-    env:
-      DOCKER_CONTENT_TRUST: 1
-    steps:
-      - uses: actions/checkout@v3.0.2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - run: sudo chown -R 1000:1000 server/
-      - run: cat .env >>"$GITHUB_ENV"
-      - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
-        env:
-          HEAD_REF: ${{github.head_ref}}
-        if: github.event_name == 'pull_request'
-      - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
-      - run: docker compose -f docker-compose.yml -f dev.docker-compose.yml pull
-      - name: Get Go version
-        id: get_go_version
-        run: |
-          CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
-          go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run server sh -c "${CMD}")
-          echo "Go version:" "${go_version}"
-          echo "::set-output name=go_version::${go_version}"
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{steps.get_go_version.outputs.go_version}}
-      - name: Install goimports
-        run: |
-          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
-          go install golang.org/x/tools/cmd/goimports@latest
-      - name: Format files
-        run: |
-          go_version=$(grep runtime app.yaml | sed -e 's/runtime: go\([0-9]\)\([0-9]*\)/\1.\2/g')
-          go mod tidy -go="${go_version}"
-          goimports -l -w .
-      - uses: dev-hato/actions-diff-pr-management@v0.0.10
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          branch-name-prefix: fix-format
-          pr-title-prefix: formatが間違ってたので直してあげたよ！
-          repo-name: ${{ github.event.pull_request.head.repo.full_name }}
-
   # npm installを実行し、package.jsonやpackage-lock.jsonに差分があればPRを作る
   update-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -645,13 +645,12 @@ jobs:
       - e2e-test-mini-prd
       - check-deploy-diff
       - update-package
-      - format-go
       - dockle
       - e2e-test-all-docker-compose
     steps:
-      - if: (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success')) && needs.update-package.result == 'success' && needs.format-go.result == 'success' && needs.dockle.result == 'success' && needs.e2e-test-all-docker-compose.result == 'success'
+      - if: (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success')) && needs.update-package.result == 'success' && needs.dockle.result == 'success' && needs.e2e-test-all-docker-compose.result == 'success'
         run: exit 0
-      - if: (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success')) || needs.update-package.result != 'success' || needs.format-go.result != 'success' || needs.dockle.result != 'success' || needs.e2e-test-all-docker-compose.result != 'success'
+      - if: (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success')) || needs.update-package.result != 'success' || needs.dockle.result != 'success' || needs.e2e-test-all-docker-compose.result != 'success'
         run: exit 1
 
   # PRをトリガーとした場合に完了しているべきjobが完了したか

--- a/.github/workflows/resource-update.yml
+++ b/.github/workflows/resource-update.yml
@@ -101,19 +101,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
-      - run: docker compose -f docker-compose.yml -f dev.docker-compose.yml pull
-      - name: Get Go version
-        id: get_go_version
-        run: |
-          DOCKER_CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
-          go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run server sh -c "${DOCKER_CMD}")
-          echo "Go version:" "${go_version}"
-          echo "::set-output name=go_version::${go_version}"
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{steps.get_go_version.outputs.go_version}}
+          go-version-file: go.mod
       - name: go mod update
         run: go get -u ./...
       - name: go mod tidy


### PR DESCRIPTION
`actions/setup-go` のバージョンを `go.mod` 準拠にします。
また、それに伴って `fotmat-go` でdocker composeを使用しなくなるので別ファイルに分離します。