### PR TITLE
e2e-test-mini-prdのタイムアウト調整

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,7 +517,7 @@ jobs:
   e2e-test-mini-prd:
     runs-on: ubuntu-latest
     concurrency: production_access
-    timeout-minutes: 3
+    timeout-minutes: 2
     needs:
       - deploy-app-engine
       - e2e-test-mini-docker-compose


### PR DESCRIPTION
`e2e-test-mini-prd` をmatrixで環境ごとに分けたので、タイムアウトを2分に短縮します。