### PR TITLE
renovateが同時に出すPRの数を1つに制限する

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.10.0
+    rev: v8.10.2
     hooks:
       - id: gitleaks

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
   ],
   "ignoreDeps": [
     "go"
-  ]
+  ],
+  "prConcurrentLimit": 1
 }


### PR DESCRIPTION
renovateが同時に出すPRの数を1つに制限することで、rebaseによるCIの再実行を減らしてみます。