### PR TITLE
ignorePathsを明記する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,15 @@
   "extends": [
     "github>dev-hato/renovate-config"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "ignoreDeps": [
     "go"
   ]


### PR DESCRIPTION
https://github.com/dev-hato/renovate-config/pull/191 でrenovateの設定のベースを `config:base` に寄せた上で、 `ignorePaths` を上書きする形にします。