### PR TITLE
FirefoxのE2Eテスト削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,7 +354,7 @@ jobs:
     needs: docker-compose-build
     strategy:
       matrix:
-        browser: ["chrome", "chromium", "firefox", "electron"]
+        browser: ["chrome", "chromium", "electron"]
     env:
       DOCKER_CONTENT_TRUST: 1
     steps:
@@ -385,7 +385,7 @@ jobs:
     needs: docker-compose-build
     strategy:
       matrix:
-        browser: ["chrome", "chromium", "firefox", "electron"]
+        browser: ["chrome", "chromium", "electron"]
     env:
       DOCKER_CONTENT_TRUST: 1
     steps:
@@ -526,7 +526,7 @@ jobs:
       - e2e-test-mini-docker-compose
     strategy:
       matrix:
-        browser: ["chrome", "chromium", "firefox", "electron"]
+        browser: ["chrome", "chromium", "electron"]
     steps:
       - uses: actions/checkout@v3.0.2
       - uses: actions/setup-node@v3.5.0
@@ -552,7 +552,7 @@ jobs:
       - e2e-test-mini-prd
     strategy:
       matrix:
-        browser: ["chrome", "chromium", "firefox", "electron"]
+        browser: ["chrome", "chromium", "electron"]
     if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.8.12
+    rev: v8.13.0
     hooks:
       - id: gitleaks

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001412",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true,
       "funding": [
         {
@@ -5247,9 +5247,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001412",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true
     },
     "chokidar": {


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/3208229783/jobs/5243908509

```
Cypress failed to make a connection to Firefox.

This usually indicates there was a problem opening the Firefox browser.

Error: connect ECONNREFUSED 127.0.0.1:36817
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1157:16)
```

Firefoxへの接続がうまく行かずFirefoxのE2Eテストが落ちるので、一旦FirefoxのE2Eテストを削除します。