### PR TITLE
CIでのFirefoxのバージョンを下げる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: 103.0.2
+          firefox-version: 104.0.2
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,11 +374,10 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
-      - run: |
-          wget https://ftp.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/en-US/firefox-100.0.2.tar.bz2
-          tar -jxvf firefox-100.0.2.tar.bz2
-          echo "PATH=$(pwd)/firefox/:${PATH}" >> $GITHUB_ENV
-          firefox --version
+      - name: Setup firefox
+        uses: browser-actions/setup-firefox@latest
+        with:
+          firefox-version: 101.0.1
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: 101.0.1
+          firefox-version: 102.0.1
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,7 +374,11 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
-      - run: firefox --version
+      - run: |
+          wget https://ftp.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/en-US/firefox-99.0.tar.bz2
+          tar -jxvf firefox-99.0.tar.bz2
+          echo "PATH=$(pwd)/firefox/:${PATH}" >> $GITHUB_ENV
+          firefox --version
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: 104.0.2
+          firefox-version: 105.0.1
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: 'projects/765091727073/locations/global/workloadIdentityPools/hato-atama-workload-identity/providers/github'
   GCP_SERVICE_ACCOUNT: 'actions-deploy@hato-atama.iam.gserviceaccount.com'
+  FIREFOX_VERSION: 104.0.2
 
 jobs:
   # App Engineにデプロイされるファイルの差分の有無を判定する
@@ -374,10 +375,10 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
-      - name: Setup firefox
-        uses: browser-actions/setup-firefox@latest
+      - uses: browser-actions/setup-firefox@v0.0.0
+        if: matrix.browser == 'firefox'
         with:
-          firefox-version: 104.0.2
+          firefox-version: ${{ env.FIREFOX_VERSION }}
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \
@@ -409,6 +410,10 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
+      - uses: browser-actions/setup-firefox@v0.0.0
+        if: matrix.browser == 'firefox'
+        with:
+          firefox-version: ${{ env.FIREFOX_VERSION }}
       - run: |
           ENV="API_HOST=http://localhost:${FRONTEND_PORT}/"
           npm run test -- --env "${ENV}" --browser ${{ matrix.browser }}
@@ -540,6 +545,10 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
+      - uses: browser-actions/setup-firefox@v0.0.0
+        if: matrix.browser == 'firefox'
+        with:
+          firefox-version: ${{ env.FIREFOX_VERSION }}
       - run: |
           API_HOST="https://"
           API_HOST+="v${GITHUB_RUN_NUMBER}-dot-hato-atama.an.r.appspot.com"
@@ -567,6 +576,10 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
+      - uses: browser-actions/setup-firefox@v0.0.0
+        if: matrix.browser == 'firefox'
+        with:
+          firefox-version: ${{ env.FIREFOX_VERSION }}
       - run: |
           ENV="API_HOST="
           ENV+="https://v${GITHUB_RUN_NUMBER}-dot-hato-atama.an.r.appspot.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: 105.0.1
+          firefox-version: 104.0.2
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,6 +374,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
+      - run: firefox --version
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: 102.0.1
+          firefox-version: 103.0.2
       - run: |
           npm run test -- --env "API_HOST=http://localhost:${FRONTEND_PORT}/" \
                           --spec cypress/e2e/mini/*.cy.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,8 +375,8 @@ jobs:
       - run: npm ci --prefer-offline
         working-directory: ./test/e2e
       - run: |
-          wget https://ftp.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/en-US/firefox-99.0.tar.bz2
-          tar -jxvf firefox-99.0.tar.bz2
+          wget https://ftp.mozilla.org/pub/firefox/releases/100.0.2/linux-x86_64/en-US/firefox-100.0.2.tar.bz2
+          tar -jxvf firefox-100.0.2.tar.bz2
           echo "PATH=$(pwd)/firefox/:${PATH}" >> $GITHUB_ENV
           firefox --version
       - run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.8.12
+    rev: v8.13.0
     hooks:
       - id: gitleaks

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001412",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true,
       "funding": [
         {
@@ -5247,9 +5247,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001412",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true
     },
     "chokidar": {


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/3208229783/jobs/5243908509

```
Cypress failed to make a connection to Firefox.

This usually indicates there was a problem opening the Firefox browser.

Error: connect ECONNREFUSED 127.0.0.1:36817
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1157:16)
```

Firefoxへの接続がうまく行かずFirefoxのE2Eテストが落ちるので、Firefoxのバージョンを104.0.2に下げます。
関連: https://github.com/cypress-io/cypress/issues/23897