### PR TITLE
Replace set-output by $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           BRANCH_NAME="$(echo '${{ matrix.directory }}' | sed -e 's:/:-:g')"
           BRANCH_NAME="${BRANCH_NAME//\./root}"
-          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
       - uses: actions/setup-node@v3.5.1
         with:
           node-version-file: ${{ matrix.directory }}/.node-version
@@ -228,8 +228,8 @@ jobs:
           npm_version=${result[1]}
           echo "Node.js version:" "${node_version}"
           echo "npm version:" "${npm_version}"
-          echo "node_version=${node_version}" >> $GITHUB_OUTPUT
-          echo "npm_version=${npm_version}" >> $GITHUB_OUTPUT
+          echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"
+          echo "npm_version=${npm_version}" >> "${GITHUB_OUTPUT}"
       - run: cat .env >>"$GITHUB_ENV"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
@@ -253,8 +253,8 @@ jobs:
           npm_version=${result[1]}
           echo "Node.js version:" "${node_version}"
           echo "npm version:" "${npm_version}"
-          echo "node_version=${node_version}" >> $GITHUB_OUTPUT
-          echo "npm_version=${npm_version}" >> $GITHUB_OUTPUT
+          echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"
+          echo "npm_version=${npm_version}" >> "${GITHUB_OUTPUT}"
       - name: Update versions
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: |
@@ -372,7 +372,7 @@ jobs:
           # shellcheck disable=SC2001
           browserslist="[$(echo "${browsers}" | sed -e 's/^\([^ ]*\) \(.*\)/{browser_name: "\1", browser_version: "\2"}/' | tr '\n' ',' | sed -e 's/,$//')]"
           echo "${browserslist}"
-          echo "browserslist=${browserslist}" >> $GITHUB_OUTPUT
+          echo "browserslist=${browserslist}" >> "${GITHUB_OUTPUT}"
 
   e2e-test-mini-docker-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
           go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run server sh -c "${CMD}")
           echo "Go version:" "${go_version}"
-          echo "go_version=${go_version}" >> $GITHUB_OUTPUT
+          echo "go_version=${go_version}" >> "${GITHUB_OUTPUT}"
       - name: Set up Go
         uses: actions/setup-go@v3
         if: github.event_name != 'pull_request' || github.event.action != 'closed'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
           go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run server sh -c "${CMD}")
           echo "Go version:" "${go_version}"
-          echo "::set-output name=go_version::${go_version}"
+          echo "go_version=${go_version}" >> $GITHUB_OUTPUT
       - name: Set up Go
         uses: actions/setup-go@v3
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
@@ -188,7 +188,7 @@ jobs:
         run: |
           BRANCH_NAME="$(echo '${{ matrix.directory }}' | sed -e 's:/:-:g')"
           BRANCH_NAME="${BRANCH_NAME//\./root}"
-          echo "::set-output name=branch_name::${BRANCH_NAME}"
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v3.5.1
         with:
           node-version-file: ${{ matrix.directory }}/.node-version
@@ -228,8 +228,8 @@ jobs:
           npm_version=${result[1]}
           echo "Node.js version:" "${node_version}"
           echo "npm version:" "${npm_version}"
-          echo "::set-output name=node_version::${node_version}"
-          echo "::set-output name=npm_version::${npm_version}"
+          echo "node_version=${node_version}" >> $GITHUB_OUTPUT
+          echo "npm_version=${npm_version}" >> $GITHUB_OUTPUT
       - run: cat .env >>"$GITHUB_ENV"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
@@ -253,8 +253,8 @@ jobs:
           npm_version=${result[1]}
           echo "Node.js version:" "${node_version}"
           echo "npm version:" "${npm_version}"
-          echo "::set-output name=node_version::${node_version}"
-          echo "::set-output name=npm_version::${npm_version}"
+          echo "node_version=${node_version}" >> $GITHUB_OUTPUT
+          echo "npm_version=${npm_version}" >> $GITHUB_OUTPUT
       - name: Update versions
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: |
@@ -372,7 +372,7 @@ jobs:
           # shellcheck disable=SC2001
           browserslist="[$(echo "${browsers}" | sed -e 's/^\([^ ]*\) \(.*\)/{browser_name: "\1", browser_version: "\2"}/' | tr '\n' ',' | sed -e 's/,$//')]"
           echo "${browserslist}"
-          echo "::set-output name=browserslist::${browserslist}"
+          echo "browserslist=${browserslist}" >> $GITHUB_OUTPUT
 
   e2e-test-mini-docker-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/resource-update.yml
+++ b/.github/workflows/resource-update.yml
@@ -77,7 +77,7 @@ jobs:
           DOCKER_CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
           go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run server sh -c "${DOCKER_CMD}")
           echo "Go version:" "${go_version}"
-          echo "go_version=${go_version}" >> $GITHUB_OUTPUT
+          echo "go_version=${go_version}" >> "${GITHUB_OUTPUT}"
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/resource-update.yml
+++ b/.github/workflows/resource-update.yml
@@ -77,7 +77,7 @@ jobs:
           DOCKER_CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
           go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run server sh -c "${DOCKER_CMD}")
           echo "Go version:" "${go_version}"
-          echo "::set-output name=go_version::${go_version}"
+          echo "go_version=${go_version}" >> $GITHUB_OUTPUT
       - name: Set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
set-output が非推奨になるらしいので `$GITHUB_OUTPUT` に置き換えた

```bash
find .github -name '*.yml' -exec sed -i 's/echo "::set-output name=\([a-zA-Z0-9_]*\)::\(.*\)"$/echo "\1=\2" >> $GITHUB_OUTPUT/' {} \;
```