### PR TITLE
Dependabotにgolang.org/x/toolsの除外設定追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
     ignore:
       - dependency-name: "golang.org/x/tools"
         versions:
-          - "<0.2.0"
+          - ">=0.2.0"
     open-pull-requests-limit: 1
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "golang.org/x/tools"
+        versions:
+          - "<0.2.0"
     open-pull-requests-limit: 1
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
`golang.org/x/tools` v0.2.0はGo 1.6に対応していないので、Dependabotのアップデート対象から除外します。