### PR TITLE
gcr-cleaner修正

### DIFF
--- a/.github/workflows/gcr-cleaner.yml
+++ b/.github/workflows/gcr-cleaner.yml
@@ -25,7 +25,7 @@ jobs:
           service_account: ${{env.GCP_SERVICE_ACCOUNT}}
 
       # customize based on the gcr-cleaner flags
-      - uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'
+      - uses: docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli:0.10.0
         with:
           args: >-
             -repo=asia-docker.pkg.dev/hato-atama/asia.gcr.io

--- a/.github/workflows/gcr-cleaner.yml
+++ b/.github/workflows/gcr-cleaner.yml
@@ -16,13 +16,13 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/checkout@v3.1.0
       - id: 'auth'
         name: 'Authenticate to GCP'
         uses: google-github-actions/auth@v1.0.0
         with:
           workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
           service_account: ${{env.GCP_SERVICE_ACCOUNT}}
-          create_credentials_file: false
 
       # customize based on the gcr-cleaner flags
       - uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/3505712047/jobs/5872185725

```
failed to fetch catalog for registry "asia-docker.pkg.dev": GET https://asia-docker.pkg.dev/v2/_catalog?n=1000: DENIED: The caller does not have permission.
```

`auth` stepで作成したクレデンシャルファイルを次のstepで参照できないと落ちるので修正します。
また、gcr-cleanerのバージョンを明示的に指定しています。