### PR TITLE
CI失敗時のSlack通知修正

### DIFF
--- a/.github/workflows/fail-notify.yml
+++ b/.github/workflows/fail-notify.yml
@@ -39,7 +39,3 @@ jobs:
           payload: ${{steps.get_slack_payload.outputs.result}}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true

--- a/.github/workflows/fail-notify.yml
+++ b/.github/workflows/fail-notify.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
+      - uses: actions/checkout@v3.1.0
       - name: Get slack payload
         id: get_slack_payload
         uses: actions/github-script@v6.3.3


### PR DESCRIPTION
checkoutし忘れていたので追加します。
また、 `workflow_run` ではrefがデフォルトブランチになる (実質的に別ブランチの内容でも重複とみなされる) ので、concurrencyを削除します。