### PR TITLE
CI失敗時のSlack通知: payloadの中身を見てみる

### DIFF
--- a/scripts/fail_notify/fail_notify/get_slack_payload.js
+++ b/scripts/fail_notify/fail_notify/get_slack_payload.js
@@ -1,4 +1,5 @@
 module.exports = ({ context }) => {
+  console.log(context.payload)
   const payload = {
     text: 'CIが失敗したっぽ......',
     attachments: [


### PR DESCRIPTION
payloadの中身を標準出力に出力します。