### PR TITLE
CI失敗時のSlack通知のattachment生成処理修正

### DIFF
--- a/scripts/fail_notify/fail_notify/get_slack_payload.js
+++ b/scripts/fail_notify/fail_notify/get_slack_payload.js
@@ -10,19 +10,22 @@ module.exports = ({ context }) => {
       }
     ]
   }
-  let displayTitle = context.payload.workflow_run.display_title
 
-  // https://api.slack.com/reference/surfaces/formatting#escaping
-  for (const replaceRule of [['&', '&amp;'], ['<', '&lt;'], ['>', '&gt;']]) {
-    displayTitle = displayTitle.replaceAll(replaceRule[0], replaceRule[1])
-  }
+  if (context.payload.workflow_run.display_title && context.payload.workflow_run.head_repository) {
+    let displayTitle = context.payload.workflow_run.display_title
 
-  if (context.payload.workflow_run.event === 'pull_request') {
-    attachment.title = 'Pull Request'
-    attachment.text = context.payload.workflow_run.pull_requests.map(p => `<${context.payload.workflow_run.head_repository.html_url}/pull/${p.number}|${displayTitle}>`).join('\n')
-  } else if (context.payload.workflow_run.head_commit && context.payload.workflow_run.head_repository) {
-    attachment.title = 'コミット'
-    attachment.text = `<${context.payload.workflow_run.head_repository.html_url}/commit/${context.payload.workflow_run.head_commit.id}|${displayTitle}>`
+    // https://api.slack.com/reference/surfaces/formatting#escaping
+    for (const replaceRule of [['&', '&amp;'], ['<', '&lt;'], ['>', '&gt;']]) {
+      displayTitle = displayTitle.replaceAll(replaceRule[0], replaceRule[1])
+    }
+
+    if (context.payload.workflow_run.event === 'pull_request' && context.payload.workflow_run.pull_requests) {
+      attachment.title = 'Pull Request'
+      attachment.text = context.payload.workflow_run.pull_requests.map(p => `<${context.payload.workflow_run.head_repository.html_url}/pull/${p.number}|${displayTitle}>`).join('\n')
+    } else if (context.payload.workflow_run.head_commit) {
+      attachment.title = 'コミット'
+      attachment.text = `<${context.payload.workflow_run.head_repository.html_url}/commit/${context.payload.workflow_run.head_commit.id}|${displayTitle}>`
+    }
   }
 
   return JSON.stringify({


### PR DESCRIPTION
PRをトリガーとしたCIであってもPRのnumberを取得できないケースがあるようなので修正します。