### PR TITLE
fail-notifyが正しいかチェックするCI追加

### DIFF
--- a/.github/workflows/check-fail-notify.yml
+++ b/.github/workflows/check-fail-notify.yml
@@ -20,16 +20,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get diff
         id: get_diff
-        run: |
-          workflows_dir=.github/workflows
-          fail_notify_workflow_file="${workflows_dir}/fail-notify.yml"
-          workflows="$(find "${workflows_dir}" -not -path "${fail_notify_workflow_file}" -type f -exec yq '.name' {} \; | sort | sed -e 's/^\(.*\)$/"\1"/g' | tr '\n' ',' | sed -e 's/,$//g')"
-          yq -i ".on.workflow_run.workflows=[${workflows}]" "${fail_notify_workflow_file}"
-          diff="$(git diff)"
-          echo "${diff}"
-          diff="${diff//'%'/'%25'}"
-          diff="${diff//$'\n'/'%0A'}"
-          diff="${diff//$'\r'/'%0D'}"
-          echo "diff=${diff}" >>"${GITHUB_OUTPUT}"
+        run: bash "${GITHUB_WORKSPACE}/scripts/check_fail_notify/check_fail_notify/get_diff.sh"
       - if: steps.get_diff.outputs.diff != ''
         run: exit 1

--- a/.github/workflows/check-fail-notify.yml
+++ b/.github/workflows/check-fail-notify.yml
@@ -27,9 +27,9 @@ jobs:
           yq -i ".on.workflow_run.workflows=[${workflows}]" "${fail_notify_workflow_file}"
           diff="$(git diff)"
           echo "${diff}"
-          result="${result//'%'/'%25'}"
-          result="${result//$'\n'/'%0A'}"
-          result="${result//$'\r'/'%0D'}"
+          diff="${diff//'%'/'%25'}"
+          diff="${diff//$'\n'/'%0A'}"
+          diff="${diff//$'\r'/'%0D'}"
           echo "diff=${diff}" >>"${GITHUB_OUTPUT}"
       - if: steps.get_diff.outputs.diff != ''
         run: exit 1

--- a/.github/workflows/check-fail-notify.yml
+++ b/.github/workflows/check-fail-notify.yml
@@ -27,6 +27,9 @@ jobs:
           yq -i ".on.workflow_run.workflows=[${workflows}]" "${fail_notify_workflow_file}"
           diff="$(git diff)"
           echo "${diff}"
+          result="${result//'%'/'%25'}"
+          result="${result//$'\n'/'%0A'}"
+          result="${result//$'\r'/'%0D'}"
           echo "diff=${diff}" >>"${GITHUB_OUTPUT}"
       - if: steps.get_diff.outputs.diff != ''
         run: exit 1

--- a/.github/workflows/check-fail-notify.yml
+++ b/.github/workflows/check-fail-notify.yml
@@ -1,5 +1,5 @@
 ---
-name: update-fail-notify
+name: check-fail-notify
 on:
   pull_request:
     types:
@@ -11,21 +11,22 @@ on:
     branches:
       - master
 jobs:
-  update-fail-notify:
+  check-fail-notify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: |
+      - name: Get diff
+        id: get_diff
+        run: |
           workflows_dir=.github/workflows
           fail_notify_workflow_file="${workflows_dir}/fail-notify.yml"
           workflows="$(find "${workflows_dir}" -not -path "${fail_notify_workflow_file}" -type f -exec yq '.name' {} \; | sort | sed -e 's/^\(.*\)$/"\1"/g' | tr '\n' ',' | sed -e 's/,$//g')"
           yq -i ".on.workflow_run.workflows=[${workflows}]" "${fail_notify_workflow_file}"
-      - uses: dev-hato/actions-diff-pr-management@v1.0.9
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          branch-name-prefix: update-fail-notify
-          pr-title-prefix: fail-notifyを修正したよ！
-          repo-name: ${{ github.event.pull_request.head.repo.full_name }}
+          diff="$(git diff)"
+          echo "${diff}"
+          echo "diff=${diff}" >>"${GITHUB_OUTPUT}"
+      - if: steps.get_diff.outputs.diff != ''
+        run: exit 1

--- a/.github/workflows/fail-notify.yml
+++ b/.github/workflows/fail-notify.yml
@@ -6,6 +6,7 @@ on:
     workflows:
       - Add to Task List
       - CodeQL
+      - check-fail-notify
       - format-json-yml
       - gcr-cleaner
       - release
@@ -17,7 +18,6 @@ on:
       - update-go-runtime
     types:
       - completed
-
 jobs:
   fail-notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/fail-notify.yml
+++ b/.github/workflows/fail-notify.yml
@@ -1,6 +1,5 @@
 ---
 name: fail-notify
-
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/update-fail-notify.yml
+++ b/.github/workflows/update-fail-notify.yml
@@ -1,0 +1,31 @@
+---
+name: update-fail-notify
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+  push:
+    branches:
+      - master
+jobs:
+  update-fail-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: |
+          workflows_dir=.github/workflows
+          fail_notify_workflow_file="${workflows_dir}/fail-notify.yml"
+          workflows="$(find "${workflows_dir}" -not -path "${fail_notify_workflow_file}" -type f -exec yq '.name' {} \; | sort | sed -e 's/^\(.*\)$/"\1"/g' | tr '\n' ',' | sed -e 's/,$//g')"
+          yq -i ".on.workflow_run.workflows=[${workflows}]" "${fail_notify_workflow_file}"
+      - uses: dev-hato/actions-diff-pr-management@v1.0.9
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          branch-name-prefix: update-fail-notify
+          pr-title-prefix: fail-notifyを修正したよ！
+          repo-name: ${{ github.event.pull_request.head.repo.full_name }}

--- a/scripts/check_fail_notify/check_fail_notify/get_diff.sh
+++ b/scripts/check_fail_notify/check_fail_notify/get_diff.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+workflows_dir=.github/workflows
+fail_notify_workflow_file="${workflows_dir}/fail-notify.yml"
+workflows="$(find "${workflows_dir}" -not -path "${fail_notify_workflow_file}" -type f -exec yq '.name' {} \; | sort | sed -e 's/^\(.*\)$/"\1"/g' | tr '\n' ',' | sed -e 's/,$//g')"
+yq -i ".on.workflow_run.workflows=[${workflows}]" "${fail_notify_workflow_file}"
+diff="$(git diff)"
+echo "${diff}"
+diff="${diff//'%'/'%25'}"
+diff="${diff//$'\n'/'%0A'}"
+diff="${diff//$'\r'/'%0D'}"
+echo "diff=${diff}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
CI `fail-notify` の `on.workflow_run.workflows` に全てのCIが網羅されているかチェックするCIを追加します。