### PR TITLE
PRがマージされるのをブロックするCI追加

### DIFF
--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -14,6 +14,7 @@ jobs:
   block-merge-pr:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3.2.0
       - uses: actions/github-script@v6.3.3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -20,7 +20,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/scripts/block-merge-pr/block-merge-pr/check-labels.js`)
-            script()
+            script({context})
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -20,8 +20,8 @@ jobs:
           result-encoding: string
           script: |
             for (const label of context.payload.pull_request.labels) {
-              if (label.name === 'duplicate') {
-                throw new Error();
+              if (label.name === 'do not merge') {
+                throw new Error('「do not merge」ラベルが付与されているためマージできません。');
               }
             }
 

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -1,0 +1,26 @@
+---
+name: block-merge-pr
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  block-merge-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6.3.3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            console.log(github.event.pull_request)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -19,7 +19,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
-            console.log(context)
+            console.log(context.payload.pull_request.labels)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -19,7 +19,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
-            console.log(github.event.pull_request)
+            console.log(context)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -17,13 +17,9 @@ jobs:
       - uses: actions/github-script@v6.3.3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          result-encoding: string
           script: |
-            for (const label of context.payload.pull_request.labels) {
-              if (label.name === 'do not merge') {
-                throw new Error('「do not merge」ラベルが付与されているためマージできません。');
-              }
-            }
+            const script = require(`${process.env.GITHUB_WORKSPACE}/scripts/block-merge-pr/block-merge-pr/check-labels.js`)
+            script()
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -19,7 +19,11 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
-            console.log(context.payload.pull_request.labels)
+            for (const label of context.payload.pull_request.labels) {
+              if (label.name === 'duplicate') {
+                return 1;
+              }
+            }
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/block-merge-pr.yml
+++ b/.github/workflows/block-merge-pr.yml
@@ -21,7 +21,7 @@ jobs:
           script: |
             for (const label of context.payload.pull_request.labels) {
               if (label.name === 'duplicate') {
-                return 1;
+                throw new Error();
               }
             }
 

--- a/.github/workflows/fail-notify.yml
+++ b/.github/workflows/fail-notify.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - Add to Task List
       - CodeQL
+      - block-merge-pr
       - check-fail-notify
       - format-json-yml
       - gcr-cleaner

--- a/scripts/block-merge-pr/block-merge-pr/check-labels.js
+++ b/scripts/block-merge-pr/block-merge-pr/check-labels.js
@@ -1,7 +1,7 @@
-module.exports = ({context}) => {
-    for (const label of context.payload.pull_request.labels) {
-        if (label.name === 'do not merge') {
-            throw new Error('「do not merge」ラベルが付与されているためマージできません。');
-        }
+module.exports = ({ context }) => {
+  for (const label of context.payload.pull_request.labels) {
+    if (label.name === 'do not merge') {
+      throw new Error('「do not merge」ラベルが付与されているためマージできません。')
     }
+  }
 }

--- a/scripts/block-merge-pr/block-merge-pr/check-labels.js
+++ b/scripts/block-merge-pr/block-merge-pr/check-labels.js
@@ -1,0 +1,7 @@
+module.exports = ({context}) => {
+    for (const label of context.payload.pull_request.labels) {
+        if (label.name === 'do not merge') {
+            throw new Error('「do not merge」ラベルが付与されているためマージできません。');
+        }
+    }
+}


### PR DESCRIPTION
PR1 -> PR2という順番でマージする前提でPR1に向けたPR2を出した際に、PR2を先にマージしたくない、といった場合にマージできなくするCIを追加します。
具体的には `do not merge` ラベルを付与するとCIが落ちます。