### PR TITLE
setup-goのcacheを有効化する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           go-version: ${{steps.get_go_version.outputs.go_version}}
+          cache: true
       - name: Install goimports
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/format_go/run_goimports.sh"

--- a/.github/workflows/resource-update.yml
+++ b/.github/workflows/resource-update.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/setup-go@v3.5.0
         with:
           go-version: ${{steps.get_go_version.outputs.go_version}}
+          cache: true
       - name: go mod update
         run: bash "${GITHUB_WORKSPACE}/scripts/resource_update/update_go/run_go_mod_tidy.sh"
       - uses: dev-hato/actions-diff-pr-management@v1.1.1


### PR DESCRIPTION
これ、多分使い方間違ってるんだけど、入れるの悪くないかもしれない

https://trap.jp/post/1655/

cacheは `setup-go-${platform}-go-${versionSpec}-${fileHash}` をキーとして入れられるため。
多分二箇所で入れてるけど、両方で同じことをしないといけない気がする。