### PR TITLE
textlint-rule-ng-word削除

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -19,7 +19,6 @@
     "ja-hiragana-hojodoushi": true,
     "ja-hiragana-keishikimeishi": true,
     "ja-unnatural-alphabet": true,
-    "ng-word": true,
     "no-dead-link": true,
     "no-mixed-zenkaku-and-hankaku-alphabet": true,
     "prefer-tari-tari": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "textlint-rule-ja-hiragana-hojodoushi": "1.1.0",
         "textlint-rule-ja-hiragana-keishikimeishi": "1.1.0",
         "textlint-rule-ja-unnatural-alphabet": "2.0.1",
-        "textlint-rule-ng-word": "1.0.0",
         "textlint-rule-no-dead-link": "5.1.2",
         "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
         "textlint-rule-prefer-tari-tari": "1.0.3",
@@ -12036,12 +12035,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/textlint-rule-ng-word": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ng-word/-/textlint-rule-ng-word-1.0.0.tgz",
-      "integrity": "sha1-s4miOepLSZL0VeKvNrsGL8bkLTk=",
-      "dev": true
-    },
     "node_modules/textlint-rule-no-dead-link": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/textlint-rule-no-dead-link/-/textlint-rule-no-dead-link-5.1.2.tgz",
@@ -23196,12 +23189,6 @@
           }
         }
       }
-    },
-    "textlint-rule-ng-word": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ng-word/-/textlint-rule-ng-word-1.0.0.tgz",
-      "integrity": "sha1-s4miOepLSZL0VeKvNrsGL8bkLTk=",
-      "dev": true
     },
     "textlint-rule-no-dead-link": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "textlint-rule-ja-hiragana-hojodoushi": "1.1.0",
     "textlint-rule-ja-hiragana-keishikimeishi": "1.1.0",
     "textlint-rule-ja-unnatural-alphabet": "2.0.1",
-    "textlint-rule-ng-word": "1.0.0",
     "textlint-rule-no-dead-link": "5.1.2",
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
     "textlint-rule-prefer-tari-tari": "1.0.3",


### PR DESCRIPTION
https://github.com/KeitaMoromizato/textlint-rule-ng-word

`textlint-rule-ng-word` のリポジトリはpublic archiveになっているので削除します。