### PR TITLE
caniuse-liteのアップデート処理削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,8 +207,6 @@ jobs:
         env:
           DIRECTORY: ${{ matrix.directory }}
         run: bash "${GITHUB_WORKSPACE}/scripts/release/update_package/set_env_and_npm_install.sh"
-      - if: matrix.directory == 'frontend'
-        run: npx update-browserslist-db
       - uses: dev-hato/actions-diff-pr-management@v1.1.3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
renovateで `caniuse-lite` を含めたlockファイル内のアップデートも行えるようになったので (例: https://github.com/dev-hato/hato-atama/pull/2763 )、CIでの `caniuse-lite` のアップデート処理を削除します。