### PR TITLE
CI Dependency Review をpushでは動かないようにする

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -1,9 +1,6 @@
 name: 'Dependency Review'
 on:
   pull_request:
-  push:
-    branches:
-      - master
 
 jobs:
   dependency-review:


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/5102842794/jobs/9172662740

```
Error: Both a base ref and head ref must be provided, either via the `base_ref`/`head_ref` config options, or by running a `pull_request`/`pull_request_target` workflow.
```

CI `Dependency Review` はpushトリガーで動かすものではなさそうなので、pushトリガーを削除します。