### PR TITLE
開発環境: 同じネットワーク内の他の端末からアクセスできないようにする

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,7 +35,7 @@ services:
       DATASTORE_EMULATOR_HOST: "gcloud_datastore:${GCLOUD_DATASOURCE_PORT}"
       PORT: ${PORT}
     ports:
-      - "${PORT}:${PORT}"
+      - "127.0.0.1:${PORT}:${PORT}"
   frontend:
     build:
       context: .
@@ -50,4 +50,4 @@ services:
       PORT: ${PORT}
       FRONTEND_PORT: ${FRONTEND_PORT}
     ports:
-      - "${FRONTEND_PORT}:${FRONTEND_PORT}"
+      - "127.0.0.1:${FRONTEND_PORT}:${FRONTEND_PORT}"


### PR DESCRIPTION
https://jun-networks.hatenablog.com/entry/2023/07/03/190000

開発環境のポートマッピングに公開先のIPアドレスを明記することで、同じネットワーク内の他の端末からアクセスできないようにします。