### PR TITLE
renovate-config-validator: --strict付与

### DIFF
--- a/scripts/renovate_config_validator/renovate_config_validator/run_validator.sh
+++ b/scripts/renovate_config_validator/renovate_config_validator/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 npm ci
-npx renovate-config-validator
+npx renovate-config-validator --strict


### PR DESCRIPTION
`renovate.json` のマイグレーションが必要な場合にCIが落ちるよう、 `renovate-config-validator` に `--strict` を付与します。