### PR TITLE
App EngineでのGoバージョンをUbuntu22で動作する最新バージョンにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,8 +409,9 @@ jobs:
         with:
           workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
           service_account: ${{env.GCP_SERVICE_ACCOUNT}}
-          install_components: app-engine-go
       - uses: google-github-actions/setup-gcloud@v1.1.1
+        with:
+          install_components: app-engine-go
       - run: gcloud components list
       - name: Deploy to App Engine
         uses: google-github-actions/deploy-appengine@v1.2.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,6 +410,7 @@ jobs:
           workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
           service_account: ${{env.GCP_SERVICE_ACCOUNT}}
       - uses: google-github-actions/setup-gcloud@v1.1.1
+      - run: gcloud components list
       - name: Deploy to App Engine
         uses: google-github-actions/deploy-appengine@v1.2.7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,10 +409,6 @@ jobs:
         with:
           workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
           service_account: ${{env.GCP_SERVICE_ACCOUNT}}
-      - uses: google-github-actions/setup-gcloud@v1.1.1
-        with:
-          install_components: app-engine-go
-      - run: gcloud components list
       - name: Deploy to App Engine
         uses: google-github-actions/deploy-appengine@v1.2.7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,6 +409,7 @@ jobs:
         with:
           workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
           service_account: ${{env.GCP_SERVICE_ACCOUNT}}
+          install_components: app-engine-go
       - uses: google-github-actions/setup-gcloud@v1.1.1
       - run: gcloud components list
       - name: Deploy to App Engine

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,6 @@
 ---
 runtime: go
+env: flex
 runtime_config:
   operating_system: "ubuntu22"
 main: ./server

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,7 @@
 ---
-runtime: go120
+runtime: go
+runtime_config:
+  operating_system: "ubuntu22"
 main: ./server
 handlers:
   - url: /api/.*


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/flexible/go/runtime?hl=ja#newversions

>Ubuntu 22 でサポートされている最新の Go バージョンを指定する:
>```yml
>  runtime: go
>  env: flex
>
>  runtime_config:
>      operating_system: "ubuntu22"
>```

上記のruntime設定を適用して、設定ファイルを書き換えなくてもある程度最新のGoを使えるようにします。