### PR TITLE
renovateでのGoのバージョンを1.20にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,5 +21,8 @@
       ],
       "allowedVersions": "<0.2.0"
     }
-  ]
+  ],
+  "constraints": {
+    "go": "1.20"
+  }
 }


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/3490 ではGo 1.21にアップデートしていますが、CodeQLやsuper-linterはまだGo 1.21に対応していないようです。
したがって、renovateでのGoのバージョンを一旦1.20にします。