### PR TITLE
format-go: goimportsのインストールをgo mod tidy後に行うようにする

### DIFF
--- a/scripts/release/format_go/run_goimports.sh
+++ b/scripts/release/format_go/run_goimports.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 echo "$(go env GOPATH)/bin" >>"${GITHUB_PATH}"
-go install golang.org/x/tools/cmd/goimports
 bash "${GITHUB_WORKSPACE}/scripts/run_go_mod_tidy.sh"
+go install golang.org/x/tools/cmd/goimports
 goimports -l -w .


### PR DESCRIPTION
goimportsのインストール -> `go mod tidy` の順だと、 `go.mod` に不備があるときに落ちてしまうので、 `go mod tidy` -> goimportsのインストールの順で実行するようにします。