### PR TITLE
Revert "textlintのCI追加 (#3536)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,39 +284,6 @@ jobs:
           DOCKER_COMPOSE_FILE_NAME: ${{matrix.docker_compose_file_name}}
           SERVICE_NAME: ${{matrix.service_name}}
         run: bash "${GITHUB_WORKSPACE}/scripts/release/dockle/run_dockle.sh"
-  lint-textlint:
-    runs-on: ubuntu-latest
-    needs: update-package
-    if: github.event_name != 'pull_request' || github.event.action != 'closed'
-    steps:
-      - uses: actions/checkout@v4.0.0
-      - uses: actions/setup-node@v3.8.1
-        with:
-          node-version-file: .node-version
-          cache: npm
-      - run: bash "${GITHUB_WORKSPACE}/scripts/release/lint_textlint/lint.sh"
-  format-textlint:
-    runs-on: ubuntu-latest
-    needs: update-package
-    steps:
-      - uses: actions/checkout@v4.0.0
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v3.8.1
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        with:
-          node-version-file: .node-version
-          cache: npm
-      - if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        run: bash "${GITHUB_WORKSPACE}/scripts/release/format_textlint/format.sh"
-        continue-on-error: true
-      - uses: dev-hato/actions-diff-pr-management@v1.1.6
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          branch-name-prefix: fix-text
-          pr-title-prefix: 日本語が間違ってたので直してあげたよ！
   make-browserslist:
     runs-on: ubuntu-latest
     needs: update-package
@@ -604,12 +571,10 @@ jobs:
       - e2e-test-mini-prd
       - check-deploy-diff
       - release-complete-check-docker-compose
-      - lint-textlint
-      - format-textlint
     steps:
-      - if: (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success' && needs.lint-textlint.result == 'success' && needs.format-textlint.result == 'success')) && needs.release-complete-check-docker-compose.result == 'success'
+      - if: (github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || (needs.lighthouse.result == 'success' && needs.e2e-test-mini-prd.result == 'success')) && needs.release-complete-check-docker-compose.result == 'success'
         run: exit 0
-      - if: (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success' || needs.lint-textlint.result != 'success' || needs.format-textlint.result != 'success')) || needs.release-complete-check-docker-compose.result != 'success'
+      - if: (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success')) || needs.release-complete-check-docker-compose.result != 'success'
         run: exit 1
   # PRをトリガーとした場合に完了しているべきjobが完了したか
   # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合はdeploy-app-engineがskipされていても完了したものと見なす

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,12 +12,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4.0.0
+      - uses: actions/setup-node@v3.8.1
+        with:
+          node-version-file: .node-version
+          cache: npm
+      - run: npm ci
       - name: Super-Linter
         uses: github/super-linter/slim@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .
-          VALIDATE_NATURAL_LANGUAGE: false
+          PATH: /github/workspace/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/node_modules/.bin:/venvs/ansible-lint/bin:/venvs/black/bin:/venvs/cfn-lint/bin:/venvs/cpplint/bin:/venvs/flake8/bin:/venvs/isort/bin:/venvs/mypy/bin:/venvs/pylint/bin:/venvs/snakefmt/bin:/venvs/snakemake/bin:/venvs/sqlfluff/bin:/venvs/yamllint/bin:/venvs/yq/bin:/var/cache/dotnet/tools:/usr/share/dotnet
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-.cache

--- a/scripts/release/format_textlint/format.sh
+++ b/scripts/release/format_textlint/format.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-npm ci
-find . -type f -name "*.md" -not -path "./node_modules/*" -print0 | xargs -0 npx textlint --fix

--- a/scripts/release/lint_textlint/lint.sh
+++ b/scripts/release/lint_textlint/lint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-npm ci
-find . -type f -name "*.md" -not -path "./node_modules/*" -print0 | xargs -0 npx textlint


### PR DESCRIPTION
This reverts commit e4352139b01e03949730f10ffca7b1fd0c32b737 ( https://github.com/dev-hato/hato-atama/pull/3536 ).

textlintのCIを分けても問題は解決しなかった ( https://github.com/dev-hato/hato-atama/pull/3551 で解決したはず) ので、textlintをsuper-linterで動かす形に戻します。