### PR TITLE
super-linterのaction名修正

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,7 +18,7 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Super-Linter
-        uses: github/super-linter/slim@v5.0.0
+        uses: super-linter/super-linter/slim@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .


### PR DESCRIPTION
https://github.com/super-linter/super-linter
>NOTICE: If your use of the super-linter action failed around April 26th, 2023, we changed the organization name from github to super-linter so you will need to update your references to this action from github/super-linter to super-linter/super-linter.

super-linterのaction名内のorganization名を修正します。
これでrenovateがアップデートしてくれるようになるはず？