### PR TITLE
renovateでのGoのバージョン指定削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,5 @@
   "ignoreDeps": [
     "go",
     "node-fetch"
-  ],
-  "constraints": {
-    "go": "1.20"
-  }
+  ]
 }


### PR DESCRIPTION
Go 1.21にアップデートできたので、renovateでのGoのバージョンの制約を削除します。