### PR TITLE
yqコマンドに-oyオプション付与

### DIFF
--- a/elm/Dockerfile
+++ b/elm/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update \
 WORKDIR /
 
 COPY frontend/elm.json ./
-RUN elm_version="$(yq -r '."elm-version"' elm.json)" \
+RUN elm_version="$(yq -oj -r '."elm-version"' elm.json)" \
     && git clone -b "${elm_version}" https://github.com/elm/compiler.git
 
 WORKDIR /compiler

--- a/elm/Dockerfile
+++ b/elm/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update \
 WORKDIR /
 
 COPY frontend/elm.json ./
-RUN elm_version="$(yq -oj -r '."elm-version"' elm.json)" \
+RUN elm_version="$(yq -oy '."elm-version"' elm.json)" \
     && git clone -b "${elm_version}" https://github.com/elm/compiler.git
 
 WORKDIR /compiler

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,7 @@ COPY frontend/elm.json ./
 RUN if [ "${TARGETPLATFORM}" != "linux/arm64" ]; then \
         curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/bin/yq; \
         chmod +x /usr/bin/yq; \
-        elm_version="$(yq -r '."elm-version"' elm.json)"; \
+        elm_version="$(yq -oj -r '."elm-version"' elm.json)"; \
         curl -L -o elm.gz "https://github.com/elm/compiler/releases/download/${elm_version}/binary-for-linux-64-bit.gz"; \
         gunzip elm.gz; \
         chmod +x elm; \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,7 @@ COPY frontend/elm.json ./
 RUN if [ "${TARGETPLATFORM}" != "linux/arm64" ]; then \
         curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/bin/yq; \
         chmod +x /usr/bin/yq; \
-        elm_version="$(yq -oj -r '."elm-version"' elm.json)"; \
+        elm_version="$(yq -oy '."elm-version"' elm.json)"; \
         curl -L -o elm.gz "https://github.com/elm/compiler/releases/download/${elm_version}/binary-for-linux-64-bit.gz"; \
         gunzip elm.gz; \
         chmod +x elm; \

--- a/scripts/release/build_frontend/build.sh
+++ b/scripts/release/build_frontend/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # https://github.com/elm/compiler/blob/24d3a89469e75cf7aa579442ecaf5ddfdd192ab2/installers/linux/README.md
-elm_version="$(yq -r '."elm-version"' elm.json)"
+elm_version="$(yq -oj -r '."elm-version"' elm.json)"
 curl -L -o elm.gz "https://github.com/elm/compiler/releases/download/${elm_version}/binary-for-linux-64-bit.gz"
 gunzip elm.gz
 chmod +x elm

--- a/scripts/release/build_frontend/build.sh
+++ b/scripts/release/build_frontend/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # https://github.com/elm/compiler/blob/24d3a89469e75cf7aa579442ecaf5ddfdd192ab2/installers/linux/README.md
-elm_version="$(yq -oj -r '."elm-version"' elm.json)"
+elm_version="$(yq -oy '."elm-version"' elm.json)"
 curl -L -o elm.gz "https://github.com/elm/compiler/releases/download/${elm_version}/binary-for-linux-64-bit.gz"
 gunzip elm.gz
 chmod +x elm


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/6618408201/job/18020431495?pr=3715

```
22:20:33 initCommand [WARN] JSON file output is now JSON by default (instead of yaml). Use '-oy' or '--output-format=yaml' for yaml output
```

上記WarningがElmのバージョン取得の箇所で出ている、かつ、YAML形式で出力すると `-r` オプションを付けなくてもダブルクオートなしの文字列になるので、該当箇所に `-oy` オプションを付与します。