### PR TITLE
shaやrefのmerge_group対応

### DIFF
--- a/.github/workflows/fix-fail-notify.yml
+++ b/.github/workflows/fix-fail-notify.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           token: ${{secrets.CREATE_WORKFLOW_CI_TOKEN}}
       - run: bash "${GITHUB_WORKSPACE}/scripts/fix_fail_notify/fix_fail_notify/fix_fail_notify.sh"
       - uses: dev-hato/actions-diff-pr-management@v1.1.6

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           token: ${{secrets.CREATE_WORKFLOW_CI_TOKEN}}
       - uses: dev-hato/actions-format-json-yml@v0.0.50
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - run: cat .env >>"$GITHUB_ENV"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - name: Build and push
         uses: docker/bake-action@v4.0.0
@@ -119,7 +119,7 @@ jobs:
       - run: cat .env >>"$GITHUB_ENV"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - name: Build and push (dev)
         uses: docker/bake-action@v4.0.0
@@ -150,12 +150,12 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/change_file_and_env.sh"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
       - name: Get Go version
         id: get_go_version
@@ -189,7 +189,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/change_file_and_env.sh"
       - name: Get Dependabot Node.js version
@@ -198,7 +198,7 @@ jobs:
         run: bash "${GITHUB_WORKSPACE}/scripts/release/update_package/get_dependabot_node_version.sh"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
       - name: Get Node.js version
         id: get_node_version
@@ -255,7 +255,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - uses: dev-hato/actions-update-dockle@v0.0.69
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -268,7 +268,7 @@ jobs:
       - run: cat .env >>"$GITHUB_ENV"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: github.event_name == 'pull_request'
       - run: bash "${GITHUB_WORKSPACE}/scripts/release/check_nginx_config/check_nginx_config.sh"
   dockle:
@@ -291,7 +291,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - env:
           DOCKER_COMPOSE_FILE_NAME: ${{matrix.docker_compose_file_name}}
@@ -332,7 +332,7 @@ jobs:
       - run: cat .env >>"$GITHUB_ENV"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - run: bash "${GITHUB_WORKSPACE}/scripts/release/run_docker_compose.sh"
       - uses: actions/setup-node@v4.0.0
@@ -366,7 +366,7 @@ jobs:
       - run: cat .env >>"$GITHUB_ENV"
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
-          HEAD_REF: ${{github.head_ref}}
+          HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - run: bash "${GITHUB_WORKSPACE}/scripts/release/run_docker_compose.sh"
       - uses: actions/setup-node@v4.0.0
@@ -430,7 +430,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - uses: actions/github-script@v6.4.1
         env:
-          SHA: ${{github.event.pull_request.head.sha}}
+          SHA: ${{github.event.pull_request.head.sha || github.event.merge_group.head_sha}}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - uses: actions/setup-node@v4.0.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:


### PR DESCRIPTION
shaやrefを `merge_group` トリガーに対応させます。
https://github.com/dev-hato/hato-atama/pull/3724 に向けています。