### PR TITLE
fail-notify: PR情報が取得できそうな場合はPRの情報を表示する

### DIFF
--- a/scripts/fail_notify/fail_notify/get_slack_payload.js
+++ b/scripts/fail_notify/fail_notify/get_slack_payload.js
@@ -18,7 +18,7 @@ module.exports = ({ context }) => {
       displayTitle = displayTitle.replaceAll(replaceRule[0], replaceRule[1])
     }
 
-    if (context.payload.workflow_run.event === 'pull_request' && context.payload.workflow_run.pull_requests.length > 0) {
+    if (context.payload.workflow_run.pull_requests.length > 0) {
       attachment.title = 'Pull Request'
       attachment.text = context.payload.workflow_run.pull_requests.map(p => `<${context.payload.workflow_run.head_repository.html_url}/pull/${p.number}|${displayTitle}>`).join('\n')
     } else if (context.payload.workflow_run.head_commit) {


### PR DESCRIPTION
`merge_group` トリガーの場合もPRの情報は取得できそうな気がするので、PRの情報を表示するケースを `pull_request` トリガーに制限しないようにします。
https://github.com/dev-hato/hato-atama/pull/3724 に向けています。