### PR TITLE
release: merge_groupトリガーの場合はcreate-pr-environmentを実行しない

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,12 +425,12 @@ jobs:
     needs: deploy-app-engine
     permissions:
       pull-requests: write
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: actions/github-script@v6.4.1
         env:
-          SHA: ${{github.event.pull_request.head.sha || github.event.merge_group.head_sha}}
+          SHA: ${{github.event.pull_request.head.sha}}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -591,7 +591,7 @@ jobs:
       - if: (github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && (needs.lighthouse.result != 'success' || needs.e2e-test-mini-prd.result != 'success')) || needs.release-complete-check-docker-compose.result != 'success'
         run: exit 1
   # PRをトリガーとした場合に完了しているべきjobが完了したか
-  # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合はdeploy-app-engineがskipされていても完了したものと見なす
+  # forkしたリポジトリからdev-hato/hato-atamaへPRを出した場合やforkしたリポジトリ上でPRを立てた場合、merge_groupトリガーの場合はcreate-pr-environmentがskipされていても完了したものと見なす
   pr-test-complete:
     runs-on: ubuntu-latest
     if: always() && ((github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'merge_group')
@@ -600,9 +600,9 @@ jobs:
       - create-pr-environment
       - check-deploy-diff
     steps:
-      - if: needs.release-complete-check.result == 'success' && (github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.create-pr-environment.result == 'success')
+      - if: needs.release-complete-check.result == 'success' && (github.event_name == 'merge_group' || github.repository != github.event.pull_request.head.repo.full_name || github.repository != 'dev-hato/hato-atama' || needs.check-deploy-diff.outputs.deploy-files == 'false' || needs.create-pr-environment.result == 'success')
         run: exit 0
-      - if: needs.release-complete-check.result != 'success' || (github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.create-pr-environment.result != 'success')
+      - if: needs.release-complete-check.result != 'success' || (github.event_name != 'merge_group' && github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'dev-hato/hato-atama' && needs.check-deploy-diff.outputs.deploy-files == 'true' && needs.create-pr-environment.result != 'success')
         run: exit 1
   action-timeline-pr-test-complete:
     needs: pr-test-complete


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/6675090675/job/18142765068

`merge_group` トリガーで `create-pr-environment` を実行しても失敗するので、実行をスキップし、スキップしてもCIとしては成功するようにします。