### PR TITLE
update-package: merge_groupのときにTAG_NAMEをセットする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
           HEAD_REF: ${{github.head_ref || github.event.merge_group.head_ref}}
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        if: github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.action != 'closed')
       - name: Get Node.js version
         id: get_node_version
         if: github.event_name != 'pull_request' || github.event.action != 'closed'


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/6952824664/job/18917433104

`merge_group` でCI `update-package` がうまく動いていないので、このような場合に `TAG_NAME` をセットするようにします。