### PR TITLE
CodeQL:  merge_groupトリガー追加

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["master"]
+  merge_group:
   schedule:
     - cron: '38 8 * * 4'
 jobs:


### PR DESCRIPTION
CodeQLをrequiredにした場合、マージキューに入れるとうまくいかないので、 `merge_group` トリガーを追加します。