### PR TITLE
renovate: Goパッケージのアップデート後にgo mod tidyを行う

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,11 @@
   "ignoreDeps": [
     "go",
     "node-fetch"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,12 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["gomod"],
-      "postUpdateOptions": ["gomodTidy"]
+      "matchManagers": [
+        "gomod"
+      ],
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
     }
   ]
 }


### PR DESCRIPTION
renovate側でGoパッケージのアップデート後に `go mod tidy` を行う設定を入れられるようなので入れてみます。