### PR TITLE
renovate: actions/download-artifactとactions/upload-artifactを1つのPRにまとめる

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,13 @@
       "postUpdateOptions": [
         "gomodTidy"
       ]
+    },
+    {
+      "groupName": "artifact",
+      "matchPackageNames": [
+        "actions/download-artifact",
+        "actions/upload-artifact"
+      ]
     }
   ]
 }


### PR DESCRIPTION
`actions/download-artifact` と `actions/upload-artifact` は同時にアップデートする必要がありそうなので、アップデートPRを1つにまとめます。