### PR TITLE
renovate: goModTidyの設定削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,14 +17,6 @@
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "postUpdateOptions": [
-        "gomodTidy"
-      ]
-    },
-    {
       "groupName": "artifact",
       "matchPackageNames": [
         "actions/download-artifact",


### PR DESCRIPTION
https://github.com/dev-hato/renovate-config/pull/1421 が入ったので、本リポジトリの設定は削除します。