### PR TITLE
pushトリガー削除

### DIFF
--- a/.github/workflows/fix-fail-notify.yml
+++ b/.github/workflows/fix-fail-notify.yml
@@ -2,9 +2,6 @@
 name: fix-fail-notify
 on:
   pull_request:
-  push:
-    branches:
-      - master
   merge_group:
 jobs:
   fix-fail-notify:

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -7,9 +7,6 @@ on:
       - synchronize
       - reopened
       - closed
-  push:
-    branches:
-      - master
   merge_group:
 permissions:
   contents: write

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,8 +1,6 @@
 ---
 name: super-linter
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
   merge_group:

--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -7,9 +7,6 @@ on:
       - synchronize
       - reopened
       - closed
-  push:
-    branches:
-      - master
   merge_group:
 permissions:
   contents: write


### PR DESCRIPTION
`merge_queue` トリガーと重複して実行されている `push` トリガーを削除します。
CI `release` については一旦スコープ外としています。