### PR TITLE
CI make-browserslist: 依存関係修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,9 @@ jobs:
         run: bash "${GITHUB_WORKSPACE}/scripts/release/dockle/run_dockle.sh"
   make-browserslist:
     runs-on: ubuntu-latest
-    needs: update-package
+    needs:
+      - update-package
+      - docker-compose-build-base
     outputs:
       browserslist: ${{ steps.set_browserslist.outputs.browserslist }}
     defaults:


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/7503124326/job/20427238008

push時にCI `make-browserslist` が実行されるよう、CI `update-package` の依存元であるCI `docker-compose-build-base` への依存を追加します。