### PR TITLE
CI make-browserslist: 実行条件調整

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,7 @@ jobs:
       - docker-compose-build-base
     outputs:
       browserslist: ${{ steps.set_browserslist.outputs.browserslist }}
+    if: always() && needs.docker-compose-build-base.result == 'success' && (github.event_name == 'push' || needs.update-package.result == 'success')
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
CI `make-browserslist` について、以下のような条件で実行されるようにします。
* pushトリガー: CI `docker-compose-build-base` が成功した場合
* その他トリガー: CI `docker-compose-build-base` とCI `update-package` が成功した場合