### PR TITLE
CI e2e-test-mini-prd: 実行条件調整

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -479,6 +479,7 @@ jobs:
       matrix:
         browser_name: ["chrome", "chromium", "electron", "edge"]
         include: ${{fromJson(needs.make-browserslist.outputs.browserslist)}}
+    if: always() && (github.event_name == 'push' || needs.e2e-test-mini-docker-compose.result == 'success') && needs.deploy-app-engine.result == 'success' && needs.make-browserslist.result == 'success'
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: actions/setup-node@v4.0.1


### PR DESCRIPTION
CI `e2e-test-mini-prd` について、以下のような条件で実行されるようにします。
* pushトリガー: CI `deploy-app-engine`, CI `make-browserslist に成功した場合
* その他トリガー: 上記に加え、CI `e2e-test-mini-docker-compose` が成功した場合