### PR TITLE
CI Add to Task List: GitHub Appのトークンの渡し方修正

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
-      - uses: dev-hato/actions-add-to-projects@v0.0.59
+      - uses: dev-hato/actions-add-to-projects@v0.0.60
         with:
           github_app_id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           github_app_private_key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}

--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -13,8 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.8.0
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: dev-hato/actions-add-to-projects@v0.0.60
         with:
-          github_app_id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          github_app_private_key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+          github-token: ${{steps.generate_token.outputs.token}}
           project-url: https://github.com/orgs/dev-hato/projects/1


### PR DESCRIPTION
`dev-hato/actions-add-to-projects` へのGitHub Appのトークンの渡し方を修正します。