### PR TITLE
App EngineのGoランタイムアップデート

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 ---
-runtime: go121
+runtime: go122
 main: ./server
 handlers:
   - url: /api/.*


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/standard/go/release-notes#March_26_2024
>[Go 1.22](https://cloud.google.com/appengine/docs/standard/go/runtime) is now [generally available](https://cloud.google.com/products/#product-launch-stages).

とのことなので、App EngineのGoランタイムを1.22にします。