### PR TITLE
CI deploy-app-engine: google-github-actions/setup-gcloud削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,7 +408,6 @@ jobs:
         with:
           workload_identity_provider: ${{env.GCP_WORKLOAD_IDENTITY_PROVIDER}}
           service_account: ${{env.GCP_SERVICE_ACCOUNT}}
-      - uses: google-github-actions/setup-gcloud@v2.1.0
       - name: Deploy to App Engine
         uses: google-github-actions/deploy-appengine@v2.1.2
         with:


### PR DESCRIPTION
https://github.com/google-github-actions/deploy-appengine?tab=readme-ov-file#usage

上記の例を見ると、 `google-github-actions/setup-gcloud` なしでも動きそうなので、 `google-github-actions/setup-gcloud` を削除します。