### PR TITLE
.golangci.yml: check-shadowingの非推奨化対応

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,8 +30,9 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: true
   govet:
-    # report about shadowed variables
-    check-shadowing: true
+    enable:
+      # report about shadowed variables
+      - shadowing
   gocyclo:
     # minimal code complexity to report, 30 by default
     min-complexity: 15


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/9111932232/job/25050124411?pr=4222

```
  level=warning msg="[config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`."
```

上記Warningに対処します。