### PR TITLE
textlint-rule-terminologyアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "textlint-rule-prefer-tari-tari": "1.0.3",
         "textlint-rule-preset-ja-spacing": "2.4.3",
         "textlint-rule-preset-ja-technical-writing": "10.0.1",
-        "textlint-rule-terminology": "5.0.10"
+        "textlint-rule-terminology": "5.0.12"
       },
       "engines": {
         "node": "^16.19.0 || ^22.2.0",
@@ -6072,9 +6072,9 @@
       }
     },
     "node_modules/textlint-rule-terminology": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-5.0.10.tgz",
-      "integrity": "sha512-+dWPNfS5F6iriG62mtfZk2zjJ85fWRemDZa8O/NM6CtdO72xpWhTYEzPCJKUVsTPE7HK57HxczmFxSRmtBkMeg==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-5.0.12.tgz",
+      "integrity": "sha512-feTwAMadVRe9Rr0LsxKdahG6e/peCjwuhxGiuGRE/H5Ys6ECgKkfRP/HVufqKxJvlrqY1S1YnHDEkvq6xTpoAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "textlint-rule-prefer-tari-tari": "1.0.3",
     "textlint-rule-preset-ja-spacing": "2.4.3",
     "textlint-rule-preset-ja-technical-writing": "10.0.1",
-    "textlint-rule-terminology": "5.0.10"
+    "textlint-rule-terminology": "5.0.12"
   },
   "engines": {
     "node": "^16.19.0 || ^22.2.0",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,4 +1,8 @@
+<!-- textlint-disable terminology -->
+
 # e2e test folder
+
+<!-- textlint-enable terminology -->
 
 ここはe2eテストのフォルダです。
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/4269 をベースに `textlint-rule-terminology` をアップデートします。