### PR TITLE
CI make-browserslist: 具体的なバージョンをmozillaから取得する

### DIFF
--- a/scripts/release/make_browserslist/set_browserslist.sh
+++ b/scripts/release/make_browserslist/set_browserslist.sh
@@ -5,18 +5,16 @@ raw_versions="$(curl https://product-details.mozilla.org/1.0/firefox.json)"
 versions="$(echo "$raw_versions" | yq -r '.releases.[] | .date + " " + .version + " " + .category' | sort -r)"
 browsers=""
 
-for version in $(npx browserslist | grep firefox | awk '{print $2}')
-do
-  version_data="$(echo "$versions" | grep " $version.[^b]* " | head -n 1)"
-  browser_version="$(echo "$version_data" | awk '{print $2}')"
-  category="$(echo "$version_data" | awk '{print $3}')"
+for version in $(npx browserslist | grep firefox | awk '{print $2}'); do
+	version_data="$(echo "$versions" | grep " $version.[^b]* " | head -n 1)"
+	browser_version="$(echo "$version_data" | awk '{print $2}')"
+	category="$(echo "$version_data" | awk '{print $3}')"
 
-  if [ "$category" = 'esr' ]
-  then
-    browser_version+=$category
-  fi
+	if [ "$category" = 'esr' ]; then
+		browser_version+=$category
+	fi
 
-  browsers+="{browser_name: \"firefox\", browser_version: \"$browser_version\"}"
+	browsers+="{browser_name: \"firefox\", browser_version: \"$browser_version\"}"
 done
 
 browserslist="[${browsers//\}\{/\},{}]"

--- a/scripts/release/make_browserslist/set_browserslist.sh
+++ b/scripts/release/make_browserslist/set_browserslist.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
 npm ci
-browsers="$(npx browserslist | grep firefox | sed -e 's/$/.0.1/')"
-# shellcheck disable=SC2001
-browserslist="[$(echo "${browsers}" | sed -e 's/^\([^ ]*\) \(.*\)/{browser_name: "\1", browser_version: "\2"}/' | tr '\n' ',' | sed -e 's/,$//')]"
+raw_versions="$(curl https://product-details.mozilla.org/1.0/firefox.json)"
+versions="$(echo "$raw_versions" | yq -r '.releases.[] | .date + " " + .version' | sort -r)"
+browsers=""
+
+for version in $(npx browserslist | grep firefox | awk '{print $2}')
+do
+  browser_version="$(echo "$versions" | grep " $version.[^b]*\$" | head -n 1 | awk '{print $2}')"
+  browsers+="{browser_name: \"firefox\", browser_version: \"$browser_version\"}"
+done
+
+browserslist="${browsers//\}\{/\},{}"
 echo "${browserslist}"
 echo "browserslist=${browserslist}" >>"${GITHUB_OUTPUT}"

--- a/scripts/release/make_browserslist/set_browserslist.sh
+++ b/scripts/release/make_browserslist/set_browserslist.sh
@@ -11,7 +11,7 @@ for version in $(npx browserslist | grep firefox | awk '{print $2}'); do
 	category="$(echo "$version_data" | awk '{print $3}')"
 
 	if [ "$category" = 'esr' ]; then
-		browser_version+=$category
+		browser_version+="$category"
 	fi
 
 	browsers+="{browser_name: \"firefox\", browser_version: \"$browser_version\"}"

--- a/scripts/release/make_browserslist/set_browserslist.sh
+++ b/scripts/release/make_browserslist/set_browserslist.sh
@@ -2,12 +2,20 @@
 
 npm ci
 raw_versions="$(curl https://product-details.mozilla.org/1.0/firefox.json)"
-versions="$(echo "$raw_versions" | yq -r '.releases.[] | .date + " " + .version' | sort -r)"
+versions="$(echo "$raw_versions" | yq -r '.releases.[] | .date + " " + .version + " " + .category' | sort -r)"
 browsers=""
 
 for version in $(npx browserslist | grep firefox | awk '{print $2}')
 do
-  browser_version="$(echo "$versions" | grep " $version.[^b]*\$" | head -n 1 | awk '{print $2}')"
+  version_data="$(echo "$versions" | grep " $version.*\$" | head -n 1)"
+  browser_version="$(echo "$version_data" | awk '{print $2}')"
+  category="$(echo "$version_data" | awk '{print $3}')"
+
+  if [ "$category" = 'esr' ]
+  then
+    browser_version+=$category
+  fi
+
   browsers+="{browser_name: \"firefox\", browser_version: \"$browser_version\"}"
 done
 

--- a/scripts/release/make_browserslist/set_browserslist.sh
+++ b/scripts/release/make_browserslist/set_browserslist.sh
@@ -11,6 +11,6 @@ do
   browsers+="{browser_name: \"firefox\", browser_version: \"$browser_version\"}"
 done
 
-browserslist="${browsers//\}\{/\},{}"
+browserslist="[${browsers//\}\{/\},{}]"
 echo "${browserslist}"
 echo "browserslist=${browserslist}" >>"${GITHUB_OUTPUT}"

--- a/scripts/release/make_browserslist/set_browserslist.sh
+++ b/scripts/release/make_browserslist/set_browserslist.sh
@@ -7,7 +7,7 @@ browsers=""
 
 for version in $(npx browserslist | grep firefox | awk '{print $2}')
 do
-  version_data="$(echo "$versions" | grep " $version.*\$" | head -n 1)"
+  version_data="$(echo "$versions" | grep " $version.[^b]* " | head -n 1)"
   browser_version="$(echo "$version_data" | awk '{print $2}')"
   category="$(echo "$version_data" | awk '{print $3}')"
 


### PR DESCRIPTION
CI `make-browserslist` において、Firefoxの具体的なバージョンを https://product-details.mozilla.org/1.0/firefox.json から取得するようにします。