### PR TITLE
sleep.jsのパスがミスってるので読み込めてなかったっぽい

### DIFF
--- a/scripts/get_run_numbers.js
+++ b/scripts/get_run_numbers.js
@@ -1,4 +1,4 @@
-const sleep = require("../../sleep.js");
+const sleep = require("./sleep.js");
 
 module.exports = async ({ github, context, core }) => {
   const HEAD_REF = process.env.HEAD_REF;


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/10762042930/job/29841909657?pr=4441

これで読めるかな？

ここがエラーになっていたので、app engineのバージョンの数がオーバーしてデプロイできてなくて、リリースが詰まってた。