### PR TITLE
CI github-actions-cache-cleaner: 権限修正

### DIFF
--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -7,7 +7,8 @@ on:
   schedule:
     - cron: "0 21 * * *" # 06:00 JST
   workflow_dispatch:
-permissions: read-all
+permissions:
+  actions: write
 jobs:
   github-actions-cache-cleaner:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/10825443491/job/30034416049

```
RequestError [HttpError]: Resource not accessible by integration
```

https://docs.github.com/ja/rest/actions/cache?apiVersion=2022-11-28#delete-github-actions-caches-for-a-repository-using-a-cache-key によると `actions: write` が必要なので、この権限を付与します。