### PR TITLE
Revert "chore(deps): update browser-actions/setup-firefox action to v1.5.3"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
@@ -375,7 +375,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
@@ -486,7 +486,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
@@ -516,7 +516,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}


### PR DESCRIPTION
Firefox 134.0.1のセットアップができなくなっているので、一旦 dev-hato/hato-atama#4769 をRevertします。

関連: https://github.com/browser-actions/setup-firefox/issues/625