### PR TITLE
lockファイルアップデート

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
@@ -375,7 +375,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
@@ -486,7 +486,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
@@ -516,7 +516,7 @@ jobs:
           cache-dependency-path: test/e2e/package-lock.json
       - if: matrix.browser_name == 'firefox'
         run: bash "${GITHUB_WORKSPACE}/scripts/release/install_firefox_dependencies.sh"
-      - uses: browser-actions/setup-firefox@e089c22a945673ab24aff2bd95b24014987f2d85 # v1.5.3
+      - uses: browser-actions/setup-firefox@955a5d42b5f068a8917c6a4ff1656a2235c66dfb # v1.5.2
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.4.tgz",
-      "integrity": "sha512-5kz9ScmzBdzTgB/3susoCgfqNDzBjvLL4taparufgSvlwjdLy6UyUy9T/tCpYd2GIdIilCatC4iSQS0QSYHt0w==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.5.tgz",
+      "integrity": "sha512-GLZPrd9ckqEBFMcVM/qRFAP0Hg3qiVEojgEFsx/N/zKXsBzbGF6z5FBDpZ0+Xhp1xr+qRZYjfGr1cWHB9oFHSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -380,9 +380,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.17",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1060,9 +1060,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001692",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
-      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
       "dev": true,
       "funding": [
         {
@@ -1610,9 +1610,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.80",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.80.tgz",
-      "integrity": "sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw==",
+      "version": "1.5.83",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
+      "integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -1721,9 +1721,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1007,9 +1007,9 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.4.tgz",
-      "integrity": "sha512-tMbOwGm6wDII6vygP3wUVqFTw3Aoo0FnVQyhihh8vVq12uO3P+vQZeo2CKMpWtPSogpACD0yyZAlVlQnjW71DA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.0.tgz",
+      "integrity": "sha512-kXLfcxhC4ozCnAXy2ff+cSxpcF0A1UqxjvYMqNuPIeOAzJbVWQ+dy5G2fTylofB/gTbObT8O6JORab+5XtA1Kw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1536,9 +1536,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1570,9 +1570,9 @@
       }
     },
     "node_modules/analyze-desumasu-dearu": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-5.0.1.tgz",
-      "integrity": "sha512-r7ruCOqvqKxAzcvDzj7PdZOstOZP9wtw/wSIoV3FmNxF16CvytxhJnHYbSRhUwqzR542OO/J9CDRWS3SSp4hZA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-5.0.2.tgz",
+      "integrity": "sha512-3PUxFk790GpQkME//hwiJellbtKMiAFX/CyA93etmAo5FujJ+5GKVXW+NU9v2MfF07iWcXsrNMbGW5/vVpqWwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2033,9 +2033,9 @@
       }
     },
     "node_modules/cheerio/node_modules/undici": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2554,9 +2554,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3311,9 +3311,9 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.6.0.tgz",
-      "integrity": "sha512-se7cpwTA+iA/eY548Bu03JJqBiEZAqU2jnyKdj5B5qurtBg64CZGHTgqCv4Yh7NWu6FGI09W61MCq+NoPj9GXA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.7.0.tgz",
+      "integrity": "sha512-XQdMjqC1AyeOzfs+17cnIk7Wdfu1hh2JtcyNfBf5u9jHrT3iZUlGHxLTntFBuk5lwkqJ6l3+daeQdHK5yByHVA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6159,9 +6159,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -7388,13 +7388,13 @@
       }
     },
     "node_modules/textlint-rule-no-mix-dearu-desumasu": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-6.0.3.tgz",
-      "integrity": "sha512-6yHxMUMEp8A267gIO9DB9ElNv5VBVNEpSUbxS6sUKZtETTGHQ3P6pdNW20EShvNfy3GA7gl1+vovkFPH8NEtYw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-6.0.4.tgz",
+      "integrity": "sha512-SmALtOFbtmJ//k2iLMvtqhGrgJ/6uDVZFK7TBj2npVAbt10VxgLL87K+62pQ/BqiN9DpOVObshVFdug7lUOKHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "analyze-desumasu-dearu": "^5.0.1",
+        "analyze-desumasu-dearu": "^5.0.2",
         "textlint-rule-helper": "^2.3.1"
       }
     },
@@ -8015,15 +8015,15 @@
       "license": "MIT"
     },
     "node_modules/traverse": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.10.tgz",
-      "integrity": "sha512-hN4uFRxbK+PX56DxYiGHsTn2dME3TVr9vbNqlQGcGcPhJAn+tdP126iA+TArMpI4YSgnTkMWyoLl5bf81Hi5TA==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.11.tgz",
+      "integrity": "sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "gopd": "^1.0.1",
-        "typedarray.prototype.slice": "^1.0.3",
-        "which-typed-array": "^1.1.15"
+        "gopd": "^1.2.0",
+        "typedarray.prototype.slice": "^1.0.5",
+        "which-typed-array": "^1.1.18"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8207,9 +8207,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -304,9 +304,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2895,22 +2895,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.71",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.71.tgz",
-      "integrity": "sha512-LQIHmHnuzfZgZWAf2HzL83TIIrD8NhhI0DVxqo9/FdOd4ilec+NTNZOlDZf7EwrTNoutccbsHjvWHYXLAtvxjw==",
+      "version": "6.1.73",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.73.tgz",
+      "integrity": "sha512-/h4bVmuEMm57c2uCiAf1Q9mlQk7cA22m+1Bu0K92vUUtTVT9D4mOFWD9r4WQuTULcG9eeZtNKhLl0Il1LdKGog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.71"
+        "tldts-core": "^6.1.73"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.71",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.71.tgz",
-      "integrity": "sha512-LRbChn2YRpic1KxY+ldL1pGXN/oVvKfCVufwfVzEQdFYNo39uF7AJa/WXdo+gYO7PTvdfkCPCed6Hkvz/kR7jg==",
+      "version": "6.1.73",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.73.tgz",
+      "integrity": "sha512-k1g5eX87vxu3g//6XMn62y4qjayu4cYby/PF7Ksnh4F4uUK1Z1ze/mJ4a+y5OjdJ+cXRp+YTInZhH+FGdUWy1w==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/4771 をベースにlockファイルをアップデートします。
なお、browser-actions/setup-firefox 1.5.3でFirefox 134.0.1のセットアップができなくなっているので ( https://github.com/dev-hato/hato-atama/actions/runs/12855740539/job/35899287710?pr=4771 )、一旦 dev-hato/hato-atama#4769 をRevertしています。

関連: https://github.com/browser-actions/setup-firefox/issues/625