### PR TITLE
CI super-linter: DEFAULT_STYLE削除

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,9 +33,7 @@ jobs:
           # Go modulesを使っているため、こちらはfalseにする
           VALIDATE_GO: false
           ESLINT_USE_FLAT_CONFIG: false
-          JAVASCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_JAVASCRIPT_STANDARD: false
-          TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_TYPESCRIPT_STANDARD: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/13347338680/job/37279403424#step:8:147

```
  2025-02-15 17:53:50 [WARN]   JAVASCRIPT_DEFAULT_STYLE environment variable is set, it's deprecated, and super-linter will ignore it. Remove it from your configuration. This warning may turn in a fatal error in the future. For more information, see the upgrade guide: https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md
  2025-02-15 17:53:50 [WARN]   TYPESCRIPT_DEFAULT_STYLE environment variable is set, it's deprecated, and super-linter will ignore it. Remove it from your configuration. This warning may turn in a fatal error in the future. For more information, see the upgrade guide: https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md
```

`JAVASCRIPT_DEFAULT_STYLE` や `TYPESCRIPT_DEFAULT_STYLE` は非推奨になっているようなので削除します。