### PR TITLE
super-linterのWarning修正

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,8 +44,8 @@ overrides:
       - "**/*.mjs"
       - "**/*.cjs"
       - "**/*.jsx"
-    extends:
-      - "plugin:react/recommended"
+    #extends:
+    #  - "plugin:react/recommended"
     parserOptions:
       sourceType: module
       ecmaVersion: latest
@@ -61,7 +61,7 @@ overrides:
     extends:
       - "plugin:@typescript-eslint/recommended"
       - plugin:n/recommended
-      - plugin:react/recommended
+      #- plugin:react/recommended
       - prettier
     rules:
       n/no-missing-import: off

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -35,6 +35,7 @@ jobs:
           ESLINT_USE_FLAT_CONFIG: false
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_TYPESCRIPT_STANDARD: false
+          VALIDATE_GIT_COMMITLINT: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,8 @@
+// https://github.com/super-linter/super-linter/blob/5d6e3fcecc2b2906eedc2d15495fd6027bf51a9e/commitlint.config.js
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  helpUrl: "https://www.conventionalcommits.org/",
+  // We need this until https://github.com/dependabot/dependabot-core/issues/2445
+  // is resolved.
+  ignores: [(msg: string) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+};

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,8 +1,0 @@
-// https://github.com/super-linter/super-linter/blob/5d6e3fcecc2b2906eedc2d15495fd6027bf51a9e/commitlint.config.js
-module.exports = {
-  extends: ["@commitlint/config-conventional"],
-  helpUrl: "https://www.conventionalcommits.org/",
-  // We need this until https://github.com/dependabot/dependabot-core/issues/2445
-  // is resolved.
-  ignores: [(msg: string) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
-};


### PR DESCRIPTION
以下のWarningを修正します。

https://github.com/dev-hato/hato-atama/actions/runs/13687019947/job/38272634863#step:8:150

```
  2025-03-05 22:45:03 [WARN]   Git commit message validation with commitlint is enabled, but no commitlint configuration file is available. Disabling commitlint. To suppress this message, either disable Git commit validation by setting VALIDATE_GIT_COMMITLINT to false in your Super-linter configuration, or provide a commitlint configuration file.
```

https://github.com/dev-hato/hato-atama/actions/runs/13687019947/job/38272634863#step:8:484

```
  Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```

https://github.com/dev-hato/hato-atama/actions/runs/13687019947/job/38272634863#step:8:747

```
  Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```