### PR TITLE
CI format-json-yml: GitHub Appでのtoken周り修正

### DIFF
--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -15,19 +15,18 @@ jobs:
   format-json-yml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          persist-credentials: false
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
-          token: ${{steps.generate_token.outputs.token}}
-          persist-credentials: false
       - uses: dev-hato/actions-format-json-yml@78a2502c69645dbbd3a56168ddc69065e7ee538c # v0.0.81
         with:
           github-token: ${{steps.generate_token.outputs.token}}


### PR DESCRIPTION
CI `format-json-yml` のGitHub Appでのtoken生成処理に関して以下を行います。
* checkout時のtokenをデフォルトのものにする
* GitHub Appでtokenを生成するタイミングをtokenを使用する直前にする