### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: test/e2e
       - run: bash "${GITHUB_WORKSPACE}/scripts/super_linter/super_linter/set_path.sh"
       - name: Super-Linter
-        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter/slim@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,43 +1,47 @@
----
-#########################
-#########################
-## Golang Linter rules ##
-#########################
-#########################
-
-# configure golangci-lint
-# see https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - dupl
-        - gosec
-        - goconst
+# Ref https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+version: "2"
 linters:
   enable:
-    - gosec
-    - unconvert
-    - gocyclo
     - goconst
-    - goimports
     - gocritic
+    - gocyclo
+    - gosec
     - govet
     - revive
-linters-settings:
-  errcheck:
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: true
-  govet:
-    enable:
-      # report about shadowed variables
-      - shadowing
-  gocyclo:
-    # minimal code complexity to report, 30 by default
-    min-complexity: 15
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
+    - unconvert
+  settings:
+    errcheck:
+      check-blank: true
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - goconst
+          - gosec
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 run:
   timeout: 1h

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.24.0
+    rev: v8.25.1
     hooks:
       - id: gitleaks


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/5023 をベースにsuper-linterをアップデートします。
`.golangci.yml` に https://github.com/super-linter/super-linter/blob/8b602a4d8b62847d02044e9bd7b19b2081631f1d/TEMPLATES/.golangci.yml を反映しています。