### PR TITLE
Dependabot: eslintをアップデート対象から除外する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,5 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "eslint"


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/4891 にてrenovateのアップデート対象から `eslint` を除外しましたが、dependabotについても同様の設定を行います。