### PR TITLE
Dependabot: node-getchを除外する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "node-fetch"
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/3578 でrenovateのアップデート対象から `node-fetch` を除外しているので、dependabotについても同様にします。