### PR TITLE
cypressアップデート

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "last 2 versions",
     "Firefox ESR",
     "not dead",
-    "not ie<=11"
+    "not ie<=11",
+    "not Firefox <= 128"
   ],
   "author": "",
   "license": "ISC",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "Firefox ESR",
     "not dead",
     "not ie<=11",
-    "not Firefox <= 128"
+    "not Firefox < 135"
   ],
   "author": "",
   "license": "ISC",

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "14.5.4",
+        "cypress": "15.0.0",
         "eslint": "9.31.0",
         "eslint-plugin-cypress": "5.1.1"
       },
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.5.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.5.4.tgz",
-      "integrity": "sha512-0Dhm4qc9VatOcI1GiFGVt8osgpPdqJLHzRwcAB5MSD/CAAts3oybvPUPawHyvJZUd8osADqZe/xzMsZ8sDTjXw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.0.0.tgz",
+      "integrity": "sha512-OH5Srk10qTzHYYt3BsP9V1DPYIAzms55s3xQn4mGmYO4k6pi25MCajDyPbiULfNDhNcthNQ2xmYvu1JdeEw1Hw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -960,7 +960,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.7.1",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
+        "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
@@ -969,7 +969,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/dashdash": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "14.5.4",
+    "cypress": "15.0.0",
     "eslint": "9.31.0",
     "eslint-plugin-cypress": "5.1.1"
   },


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/5262 をベースにcypressをアップデートします。

https://github.com/dev-hato/hato-atama/actions/runs/17128137596/job/48591834244?pr=5262

```
Cypress does not support running Firefox version 128 due to lack of WebDriver BiDi support. To use Firefox with Cypress, install version 135 or newer.
```

cypress v15ではFirefox 135以降をサポートするようなので、135以前はサポート対象外にしています。