### PR TITLE
dependabot: 3日以上経ったnpmパッケージのみをアップデート対象にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,11 +51,15 @@ updates:
     open-pull-requests-limit: 1
     ignore:
       - dependency-name: "node-fetch"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    cooldown:
+      default-days: 3
   - package-ecosystem: "npm"
     directory: "/test/e2e"
     schedule:
@@ -63,3 +67,5 @@ updates:
     open-pull-requests-limit: 1
     ignore:
       - dependency-name: "eslint"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
https://tech.dentsusoken.com/entry/dependabot_cooldown

https://github.com/dev-hato/renovate-config/pull/1808 と同様の設定をdependabotに対して行います。