### PR TITLE
GoのベースイメージをDebian Trixieベースにする

### DIFF
--- a/scripts/release/dockle/run_dockle.sh
+++ b/scripts/release/dockle/run_dockle.sh
@@ -23,7 +23,7 @@ for image_name in $(docker compose -f compose.yml -f "${DOCKER_COMPOSE_FILE_NAME
 		if [[ "${image_name}" =~ "server-dev" ]] || [[ "${image_name}" =~ "server-base" ]]; then
 			cmd+="--timeout 600s "
 			if [[ "${image_name}" =~ "server-dev" ]]; then
-				cmd+="-af credentials "
+				cmd+="-i DKL-DI-0005 -af credentials "
 			fi
 		fi
 	elif [[ "${image_name}" =~ "frontend:" ]]; then

--- a/scripts/release/dockle/run_dockle.sh
+++ b/scripts/release/dockle/run_dockle.sh
@@ -23,8 +23,12 @@ for image_name in $(docker compose -f compose.yml -f "${DOCKER_COMPOSE_FILE_NAME
 		if [[ "${image_name}" =~ "server-dev" ]] || [[ "${image_name}" =~ "server-base" ]]; then
 			cmd+="--timeout 600s "
 			if [[ "${image_name}" =~ "server-dev" ]]; then
-				cmd+="-i DKL-DI-0005 -af credentials "
+				cmd+="-af credentials "
 			fi
+		fi
+
+		if [[ "${image_name}" =~ "server-base" ]]; then
+			cmd+="-i DKL-DI-0005 "
 		fi
 	elif [[ "${image_name}" =~ "frontend:" ]]; then
 		cmd+="-ak NGINX_GPGKEY "

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-bullseye@sha256:2cdc80dc25edcb96ada1654f73092f2928045d037581fa4aa7c40d18af7dd85a AS base
+FROM golang:1.24.6-trixie@sha256:00118997097abd33e580b60a077dfafd18368d6f50240015ea3da68319ddb357 AS base
 
 WORKDIR /go/app
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,6 +19,7 @@ RUN mapfile -t PLATFORM < <(echo "${TARGETPLATFORM}" | tr '/' ' ') \
     && CGO_ENABLED=0 GOOS=linux GOARCH=${PLATFORM[2]} go build -o ping
 
 WORKDIR /go/app/server
+# hadolint ignore=DL3062
 RUN mapfile -t PLATFORM < <(echo "${TARGETPLATFORM}" | tr '/' ' ') \
     && CGO_ENABLED=0 GOOS=linux GOARCH=${PLATFORM[2]} go build -o app \
     && go install github.com/air-verse/air \


### PR DESCRIPTION
https://github.com/docker-library/golang/pull/564 にてDebian Bullseyeベースのgolangイメージがdropされたようなので、Debian Trixieベースにします。