### PR TITLE
golangアップデート

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 ---
-runtime: go125
+runtime: go126
 main: ./server
 handlers:
   - url: /api/.*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dev-hato/hato-atama
 
-go 1.25.6
+go 1.26.0
 
 require (
 	cloud.google.com/go/datastore v1.22.0

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-trixie@sha256:0032c99f1682c40dca54932e2fe0156dc575ed12c6a4fdec94df9db7a0c17ab0 AS base
+FROM golang:1.26.0-trixie@sha256:4e603da0ea8df4a8ab10cbf0b3061f7823d277e82ea210a47c32a5fafb43cc43 AS base
 
 WORKDIR /go/app
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/5761 をベースにgolangをアップデートします。