### PR TITLE
CI super-linter: PRへの書き込み権限付与

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: write
   statuses: write
 jobs:
   super-linter:


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/actions/runs/24245601978/job/70790955917?pr=5869#step:8:932

```
2026-04-10 13:38:40 [WARN]   Failed to call GitHub API (https://api.github.com/repos/dev-hato/hato-atama/issues/5869/comments): curl: (22) The requested URL returned error: 403
```

上記Warningを解消するため、CI `super-linter` に `pull-requests: write` を付与します。