### PR TITLE
actions公式のadd-to-projectを使う

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
-      - uses: dev-hato/actions-add-to-projects@4f20d0bdaeabd4b7728bbea294e2c5264c082611 # v0.0.109
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           github-token: ${{steps.generate_token.outputs.token}}
           project-url: https://github.com/orgs/dev-hato/projects/1


### PR DESCRIPTION
公式の
https://github.com/actions/add-to-project
があった

https://github.com/dev-hato/actions-add-to-projects
の最初の頃は、

https://github.com/actions/add-to-project/releases/tag/v0.0.1
を見る感じ、まだ無かったんだと思う。あったとしても知られてなかった。

多分それ以外に理由ないよね・・・？