### PR TITLE
fix(frontend): webpack devServer.proxy を配列形式に修正

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -40,8 +40,10 @@ module.exports = {
     host: "0.0.0.0",
     hot: true,
     proxy: [
-      { context: ["/api/"], target: `http://server:${process.env.PORT}` },
-      { context: ["/l/"], target: `http://server:${process.env.PORT}` },
+      {
+        context: ["/api/", "/l/"],
+        target: `http://server:${process.env.PORT}`,
+      },
     ],
   },
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -40,8 +40,8 @@ module.exports = {
     host: "0.0.0.0",
     hot: true,
     proxy: [
-      {context: ["/api/"], target: `http://server:${process.env.PORT}`},
-      {context: ["/l/"], target: `http://server:${process.env.PORT}`},
+      { context: ["/api/"], target: `http://server:${process.env.PORT}` },
+      { context: ["/l/"], target: `http://server:${process.env.PORT}` },
     ],
   },
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -39,9 +39,9 @@ module.exports = {
     port: process.env.FRONTEND_PORT,
     host: "0.0.0.0",
     hot: true,
-    proxy: {
-      "/api/": `http://server:${process.env.PORT}`,
-      "/l/": `http://server:${process.env.PORT}`,
-    },
+    proxy: [
+      {context: ["/api/"], target: `http://server:${process.env.PORT}`},
+      {context: ["/l/"], target: `http://server:${process.env.PORT}`},
+    ],
   },
 };


### PR DESCRIPTION
```
frontend-1  | > hato-atama@1.0.0 dev
frontend-1  | > webpack serve --mode development
frontend-1  | 
frontend-1  | [webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
frontend-1  |  - options.proxy should be an array:
frontend-1  |    [object { … } | function, ...]
frontend-1  |    -> Allows to proxy requests, can be useful when you have a separate API backend development server and you want to send API requests on the same domain.
frontend-1  |    -> Read more at https://webpack.js.org/configuration/dev-server/#devserverproxy
```

webpack-dev-server の新しいスキーマに合わせて proxy をオブジェクトから配列形式に変更します。