### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: test/e2e
       - run: bash "${GITHUB_WORKSPACE}/scripts/super_linter/super_linter/set_path.sh"
       - name: Super-Linter
-        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,6 +87,10 @@ export default defineConfig([
       ecmaVersion: "latest",
       sourceType: "module",
     },
+
+    rules: {
+      "n/no-missing-import": "off",
+    },
   },
   ...pluginVue.configs["flat/recommended"],
 ]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-// https://github.com/super-linter/super-linter/blob/58ee821839c7e0d8979f759a8e5ca0d99bb50737/TEMPLATES/eslint.config.mjs
+// https://github.com/super-linter/super-linter/blob/19a4b8c7dddfaf934ced443c7deed5215f8c1d07/TEMPLATES/eslint.config.mjs
 import { defineConfig, globalIgnores } from "eslint/config";
 import n from "eslint-plugin-n";
 import prettier from "eslint-plugin-prettier";
@@ -69,12 +69,14 @@ export default defineConfig([
   {
     files: ["**/*.ts", "**/*.cts", "**/*.mts", "**/*.tsx"],
 
-    extends: compat.extends(
-      "plugin:@typescript-eslint/recommended",
-      "plugin:n/recommended",
-      "plugin:react/recommended",
-      "prettier",
-    ),
+    extends: [
+      n.configs["flat/recommended"],
+      compat.extends(
+        "plugin:@typescript-eslint/recommended",
+        "plugin:react/recommended",
+        "prettier",
+      ),
+    ],
 
     plugins: {
       "@typescript-eslint": typescriptEslint,
@@ -84,10 +86,6 @@ export default defineConfig([
       parser: tsParser,
       ecmaVersion: "latest",
       sourceType: "module",
-    },
-
-    rules: {
-      "n/no-missing-import": "off",
     },
   },
   ...pluginVue.configs["flat/recommended"],

--- a/server/main.go
+++ b/server/main.go
@@ -23,6 +23,8 @@ var (
 	envName  string
 )
 
+const databaseErrMessage = "database error"
+
 type ShortURLDataType struct {
 	Count   int64
 	URLData string
@@ -138,7 +140,7 @@ func createShortURL(c *echo.Context) (err error) {
 	tx, err := dsClient.NewTransaction(c.Request().Context())
 	if err != nil {
 		c.Logger().Error(err.Error())
-		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: "database error"})
+		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: databaseErrMessage})
 	}
 
 	if inputData.WantedShortURL == nil {
@@ -150,7 +152,7 @@ func createShortURL(c *echo.Context) (err error) {
 			key, hashKey, err = getKey(hashedURL[:i], tx)
 			if err != nil {
 				c.Logger().Error(err.Error())
-				return c.JSON(http.StatusInternalServerError, RetJSONType{Message: "database error"})
+				return c.JSON(http.StatusInternalServerError, RetJSONType{Message: databaseErrMessage})
 			}
 		}
 
@@ -164,7 +166,7 @@ func createShortURL(c *echo.Context) (err error) {
 		key, hashKey, err = getKey(*inputData.WantedShortURL, tx)
 		if err != nil {
 			c.Logger().Error(err.Error())
-			return c.JSON(http.StatusInternalServerError, RetJSONType{Message: "database error"})
+			return c.JSON(http.StatusInternalServerError, RetJSONType{Message: databaseErrMessage})
 		} else if hashKey == "" { // 希望するURLが存在してしまったので、登録できなかった
 			message := "No usable key: " + *inputData.WantedShortURL
 			c.Logger().Error(message)
@@ -178,13 +180,13 @@ func createShortURL(c *echo.Context) (err error) {
 		Count:   *inputData.Count,
 	}); err != nil {
 		c.Logger().Error(err.Error())
-		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: "database error"})
+		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: databaseErrMessage})
 	}
 
 	// トランザクションを確定させる
 	if _, err = tx.Commit(); err != nil {
 		c.Logger().Error(err.Error())
-		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: "database error"})
+		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: databaseErrMessage})
 	}
 
 	return c.JSON(http.StatusCreated, RetJSONType{Status: true, Message: "ok", HashKey: &hashKey})
@@ -200,7 +202,7 @@ func getLink(c *echo.Context) (err error) {
 	tx, err := dsClient.NewTransaction(c.Request().Context())
 	if err != nil {
 		c.Logger().Error(err.Error())
-		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: "database error"})
+		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: databaseErrMessage})
 	}
 
 	// 取り出す入れ物の作成
@@ -217,7 +219,7 @@ func getLink(c *echo.Context) (err error) {
 
 		// その他のエラー
 		c.Logger().Error(err.Error())
-		return c.JSON(http.StatusInternalServerError, RetJSONType{Status: false, Message: "database error"})
+		return c.JSON(http.StatusInternalServerError, RetJSONType{Status: false, Message: databaseErrMessage})
 	}
 
 	// データは存在するけど忘れてしまった
@@ -231,13 +233,13 @@ func getLink(c *echo.Context) (err error) {
 	// 一回引いた値を保存する
 	if _, err = tx.Put(key, data); err != nil {
 		c.Logger().Error(err.Error())
-		return c.JSON(http.StatusInternalServerError, RetJSONType{Status: false, Message: "database error"})
+		return c.JSON(http.StatusInternalServerError, RetJSONType{Status: false, Message: databaseErrMessage})
 	}
 
 	// トランザクションを確定させる
 	if _, err = tx.Commit(); err != nil {
 		c.Logger().Error(err.Error())
-		return c.JSON(http.StatusInternalServerError, RetJSONType{Status: false, Message: "database error"})
+		return c.JSON(http.StatusInternalServerError, RetJSONType{Status: false, Message: databaseErrMessage})
 	}
 
 	c.Response().Header().Set("Cache-Control", "no-store")

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "cypress": "15.17.0",
-        "eslint": "9.39.2",
+        "eslint": "9.39.4",
         "eslint-plugin-cypress": "6.4.1"
       },
       "engines": {
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1066,25 +1066,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -1103,7 +1103,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "devDependencies": {
     "cypress": "15.17.0",
-    "eslint": "9.39.2",
+    "eslint": "9.39.4",
     "eslint-plugin-cypress": "6.4.1"
   },
   "packageManager": "npm@11.7.0",


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/6066 をベースにsuper-linterをアップデートします。

https://github.com/dev-hato/hato-atama/actions/runs/28276704266/job/83784614419#step:8:653

```
  server/main.go:141:70: string `database error` has 9 occurrences, make it a constant (goconst)
  		return c.JSON(http.StatusInternalServerError, RetJSONType{Message: "database error"})
  		                                                                   ^
```

上記を修正するため、 `"database error"` を定数として切り出しています。