### PR TITLE
build(deps): golangのrc版をdependabotのアップデート対象から除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "golang"
+        versions:
+          - "*rc*"
     cooldown:
       default-days: 7
   - package-ecosystem: "elm"


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/6105 のように、dependabotによってgolangのrc版のアップデートPRが出されることがあるので、rc版はアップデート対象から除外します。