### PR TITLE
Revert build(deps): golangのrc版をdependabotのアップデート対象から除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,10 +31,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
-    ignore:
-      - dependency-name: "golang"
-        versions:
-          - "*rc*"
     cooldown:
       default-days: 7
   - package-ecosystem: "elm"


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/runs/86247738104

上記のエラーが出ているので dev-hato/hato-atama#6110 をRevertします。