### PR TITLE
fix(ci): E2Eテストで使用するMicrosoft Edgeのバージョンを固定する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,6 +366,8 @@ jobs:
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
+      - if: matrix.browser_name == 'edge'
+        run: bash "${GITHUB_WORKSPACE}/scripts/release/install_edge.sh"
       - run: bash "${GITHUB_WORKSPACE}/scripts/release/set_docker_compose_test_env.sh"
       - env:
           BROWSER_NAME: ${{ matrix.browser_name }}
@@ -409,6 +411,8 @@ jobs:
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
+      - if: matrix.browser_name == 'edge'
+        run: bash "${GITHUB_WORKSPACE}/scripts/release/install_edge.sh"
       - run: bash "${GITHUB_WORKSPACE}/scripts/release/set_docker_compose_test_env.sh"
       - env:
           BROWSER_NAME: ${{ matrix.browser_name }}
@@ -509,7 +513,7 @@ jobs:
           path: ${{ env.ARTIFACT_PATH }}
   e2e-test-mini-prd:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 4
     needs:
       - deploy-app-engine
       - e2e-test-mini-docker-compose
@@ -533,6 +537,8 @@ jobs:
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
+      - if: matrix.browser_name == 'edge'
+        run: bash "${GITHUB_WORKSPACE}/scripts/release/install_edge.sh"
       - run: bash "${GITHUB_WORKSPACE}/scripts/release/set_prod_test_env.sh"
       - env:
           BROWSER_NAME: ${{ matrix.browser_name }}
@@ -540,7 +546,7 @@ jobs:
         working-directory: ./test/e2e
   e2e-test-all-prd:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     needs:
       - e2e-test-all-docker-compose
       - e2e-test-mini-prd
@@ -565,6 +571,8 @@ jobs:
         if: matrix.browser_name == 'firefox'
         with:
           firefox-version: ${{ matrix.browser_version }}
+      - if: matrix.browser_name == 'edge'
+        run: bash "${GITHUB_WORKSPACE}/scripts/release/install_edge.sh"
       - run: bash "${GITHUB_WORKSPACE}/scripts/release/set_prod_test_env.sh"
       - env:
           BROWSER_NAME: ${{ matrix.browser_name }}

--- a/scripts/release/install_edge.sh
+++ b/scripts/release/install_edge.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# GitHub ActionsランナーにプリインストールされているEdgeは自動更新され、Cypressとの接続が不安定になるバージョンが混ざることがある
+# そのため、動作実績のある特定バージョンに固定してインストールする
+EDGE_VERSION="149.0.4022.98-1"
+DEB_FILE="microsoft-edge-stable_${EDGE_VERSION}_amd64.deb"
+DEB_PATH="/tmp/${DEB_FILE}"
+
+curl -fsSL --retry 3 --retry-delay 2 -o "${DEB_PATH}" "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/${DEB_FILE}"
+sudo apt-get update
+sudo dpkg -i "${DEB_PATH}"


### PR DESCRIPTION
GitHub Actionsのubuntu-latestランナーにプリインストールされたEdgeが自動更新され、 CypressとのCDP接続が不安定になる問題が発生していたため、動作実績のあるバージョンを明示的にインストールするようにした。
あわせて、インストール処理の時間を確保するためprd向けe2eジョブのタイムアウトを延長した。