### PR TITLE
ルートディレクトリ以外にもTakumiを設定する

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 legacy-peer-deps=true
+registry=https://npm.flatt.tech/

--- a/test/e2e/.npmrc
+++ b/test/e2e/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/6100 ではルートディレクトリの `.npmrc` のみにTakumiの設定を行いましたが、それ以外のディレクトリの `.npmrc` にも同様の設定を行います。